### PR TITLE
Reader overhaul + Random rotation test

### DIFF
--- a/src/Forcefield.jl
+++ b/src/Forcefield.jl
@@ -148,7 +148,7 @@ function check_forcefield_coverage(framework::Framework, ljforcefield::LennardJo
         return true
     else
         @printf("Framework %s possesses the following atoms not covered by the forcefield %s:\n", framework.name, ljforcefield.name)
-        println(missing_atoms)
+        println(string(missing_atoms))
         return false
     end
 end
@@ -167,7 +167,7 @@ function check_forcefield_coverage(molecule::Molecule, ljforcefield::LennardJone
         return true
     else
         @printf("Molecule %s possesses the following atoms not covered by the forcefield %s:\n", molecule.species, ljforcefield.name)
-        println(missing_atoms)
+        println(string(missing_atoms))
         return false
     end
 end

--- a/src/PorousMaterials.jl
+++ b/src/PorousMaterials.jl
@@ -14,7 +14,7 @@ include("Grid.jl")
 include("MChelpers.jl")
 include("GCMC.jl")
 
-export Box, Framework, read_crystal_structure_file, replicate_to_xyz,
+export Box, Framework, read_crystal_structure_file, replicate_to_xyz, remove_overlapping_atoms,
        strip_numbers_from_atom_labels!, write_unitcell_boundary_vtk, chemical_formula, molecular_weight, crystal_density,
        convert_cif_to_P1_symmetry, construct_box, replicate_box, read_atomic_masses, charged, # Crystal.jl
        LennardJonesForceField, read_forcefield_file, replication_factors, check_forcefield_coverage, # Forcefield.jl

--- a/test/data/crystals/test_structure2B.cif
+++ b/test/data/crystals/test_structure2B.cif
@@ -1,0 +1,26 @@
+data_test2
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   10.0
+_cell_length_b   20.0
+_cell_length_c   30.0
+_cell_angle_alpha   90.0
+_cell_angle_beta   45.0
+_cell_angle_gamma   120.0
+_symmetry_Int_Tables_number   1
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_label
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_charge
+ Ca 0.2 0.5 0.7   1.0
+ Ca 0.2 0.5 0.7   1.0
+ Ca 0.2 0.5 0.7   1.0
+ Ca 0.2 0.5 0.7   1.0
+ O 0.6 0.3 0.1   -1.0
+ O 0.6 0.3 0.1   -1.0
+ O 0.6 0.3 0.1   -1.0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,8 +9,9 @@ using Base.Test
 
 # Run Tests
 
-@printf("------------------------------\nTesting Crystal.jl\n\n")
+@printf("\n------------------------------\nTesting Crystal.jl\n\n")
 framework = read_crystal_structure_file("test_structure2.cif")
+framework2 = read_crystal_structure_file("test_structure2B.cif", remove_overlap = true)
 strip_numbers_from_atom_labels!(framework)
 @testset "Crystal Tests" begin
     @test framework.name == "test_structure2.cif"
@@ -31,6 +32,7 @@ strip_numbers_from_atom_labels!(framework)
     @test chemical_formula(framework) == Dict(:Ca => 1, :O => 1)
     @test molecular_weight(framework) ≈ 15.9994 + 40.078
     @test isapprox(transpose(framework.box.reciprocal_lattice), 2 * π * inv(framework.box.f_to_c))
+    @test framework.atoms == framework2.atoms && framework.xf == framework2.xf && framework.charges == framework2.charges
 
     # test .cssr reader too; test_structure2.{cif,cssr} designed to be the same.
     framework_from_cssr = read_crystal_structure_file("test_structure2.cif")
@@ -38,7 +40,7 @@ strip_numbers_from_atom_labels!(framework)
     @test isapprox(framework_from_cssr, framework, checknames=false)
 end;
 
-@printf("------------------------------\nTesting Forcefield.jl\n\n")
+@printf("\n------------------------------\nTesting Forcefield.jl\n\n")
 const ljforcefield = read_forcefield_file("Dreiding.csv", cutoffradius=12.5, mixing_rules="Lorentz-Berthelot") # Dreiding
 frame = read_crystal_structure_file("test_structure.cif") # .cif
 strip_numbers_from_atom_labels!(frame)
@@ -60,7 +62,7 @@ rep_factors = replication_factors(frame.box, ljforcefield)
     @test !check_forcefield_coverage(framework10, ljforcefield)
 end;
 
-@printf("------------------------------\nTesting Molecules.jl\n\n")
+@printf("\n------------------------------\nTesting Molecules.jl\n\n")
 @testset "Molecules Tests" begin
     # test reader
     molecule = read_molecule_file("CO2")
@@ -169,7 +171,7 @@ end;
 
 end
 
-@printf("------------------------------\nTesting Energetics.jl\n\n")
+@printf("\n------------------------------\nTesting Energetics.jl\n\n")
 @testset "Energetics Tests" begin
     # test Periodic boundary conditions
     molecule1 = read_molecule_file("He")
@@ -233,10 +235,10 @@ end
     @test isapprox(v + PotentialEnergy(2.0, 3.0, 4.0, 5.0), PotentialEnergy(5.0, 7.0, 9.0, 11.0))
     @test isapprox(v - PotentialEnergy(2.0, 3.0, 4.0, 5.0), PotentialEnergy(1.0, 1.0, 1.0, 1.0))
 end;
-@printf("------------------------------\n")
+#@printf("------------------------------\n")
 
 
-@printf("------------------------------\nTesting Ewald.jl\n\n")
+@printf("\n------------------------------\nTesting Ewald.jl\n\n")
 framework = read_crystal_structure_file("NU-1000_Greg.cif")
 
 k_rep_factors = (11, 11, 9)
@@ -262,9 +264,9 @@ q_test = 0.8096
     ϕ = electrostatic_potential(framework, x, sim_box, rep_factors, sr_cutoff, kvectors, α)
     @test isapprox(ϕ * q_test, -2676.8230141, atol=0.5)
 end
-@printf("------------------------------\n")
+#@printf("------------------------------\n")
 
-@printf("------------------------------\nTesting GCMC.jl\n\n")
+@printf("\n------------------------------\nTesting GCMC.jl\n\n")
 @testset "Monte Carlo Functions Tests" begin
     # replicating the unit cell to construct simulation box
     sbmof1 = read_crystal_structure_file("SBMOF-1.cif")


### PR DESCRIPTION
Some polishing for the `read_crystal_structure_file` function.
    `remove_overlap` is a new bool argument for the function which enables the removal of identical overlapping atoms. It calls upon the remove_overlapping_atoms function (which also runs relevant checks like overlap/charge_neutral)
    If `run_checks = false` in `read_crystal_structure_file` we'll remove identical atoms and we won't be checking if the result is charge neutral or if different elements are overlapping.
    I made a new test structure, `test_structure2B.cif`, which is identical to `test_structure2.cif`, except I copied the atoms multiple times (and got rid of the number on their labels). To test the remove_overlap I compare the framework for `test_structure2.cif` and `test_structure2B.cif` (fractional coords, atoms and charges)

For uniformly random rotation test I use a randomly generated radius (from `rand()`) and form a patch on the sphere and count the points on that patch. Then I use `rotation_matrix()` to rotate the sphere and count the points that landed on that same patch. I make sure number of points on the patch is similar. The tolerance in that check is 1% of the sample size, which is 1M points.
I run this test with three randomly generated radii to make sure that doesn't affect the result.

-Arni