### PR TITLE
Henry autosave scale insertions

### DIFF
--- a/test/henry_test.jl
+++ b/test/henry_test.jl
@@ -1,7 +1,7 @@
 using PorousMaterials
 using Base.Test
 
-insertions_per_volume = 1
+insertions_per_volume = 500
 
 @testset "Henry coefficient tests" begin
 ###

--- a/test/henry_test.jl
+++ b/test/henry_test.jl
@@ -1,7 +1,7 @@
 using PorousMaterials
 using Base.Test
 
-nb_insertions = 1000000
+insertions_per_volume = 1
 
 @testset "Henry coefficient tests" begin
 ###
@@ -13,7 +13,7 @@ molecule = read_molecule_file("Xe")
 temperature = 298.0
 
 result = henry_coefficient(framework, molecule, temperature, ljff, 
-                           nb_insertions=nb_insertions, verbose=true)
+                           insertions_per_volume=insertions_per_volume, verbose=true)
 @test isapprox(result["henry coefficient [mol/(kg-Pa)]"], 0.00985348, atol=0.0002)
 @test isapprox(result["⟨U⟩ (kJ/mol)"], -39.6811, atol=0.1)
 
@@ -26,7 +26,7 @@ molecule = read_molecule_file("CO2")
 temperature = 298.0
 
 result = henry_coefficient(framework, molecule, temperature, ljff, 
-                           nb_insertions=nb_insertions, verbose=true)
+                           insertions_per_volume=insertions_per_volume, verbose=true)
 @test isapprox(result["henry coefficient [mol/(kg-Pa)]"], 2.88317e-05, atol=1.5e-7)
 @test isapprox(result["⟨U⟩ (kJ/mol)"], -18.69582223, atol=0.1)
 


### PR DESCRIPTION
- autosave henry coefficient results as JLD in `PATH_TO_DATA * "henry_sims"` via passing `autosave=true`
- scale number of insertions with volume of the xtal.