### PR TITLE
Fix grid reader

### DIFF
--- a/src/Grid.jl
+++ b/src/Grid.jl
@@ -113,7 +113,7 @@ function read_cube(filename::AbstractString)
     end
     
     # reconstruct box from f_to_c matrix
-    box = construct_box(f_to_c)
+    box = Box(f_to_c)
 
     # read in data
     data = zeros(Float64, n_pts...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -826,6 +826,14 @@ end
     @test vdw_energy(2, molecules_co2, ljforcefield, sim_box_large) ≈ energy
 end
 
+@testset "Grid Tests" begin
+    grid = Grid(Box(0.7, 0.8, 0.9, 1.5, 1.6, 1.7), (3, 3, 3), rand((3, 3, 3)), 
+        :kJ_mol, [1., 2., 3.])
+    write_cube(grid, "test_grid.cube")
+    grid2 = read_cube("test_grid.cube")
+    @test isapprox(grid, grid2)
+end
+
 @testset "EOS Tests" begin
     # Peng-Robinsion EOS test for methane.
     gas = PengRobinsonGas(:CH4)


### PR DESCRIPTION
vestige of old box constructor was fixed so `read_cube` could work; I also added a test for consistency of `read_cube`/`write_cube`