### PR TITLE
Making PorousMaterials Precompile

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/SimonEnsemble/PorousMaterials.jl.svg?branch=master)](https://travis-ci.org/SimonEnsemble/PorousMaterials.jl) [![Coverage Status](https://coveralls.io/repos/github/SimonEnsemble/PorousMaterials.jl/badge.svg?branch=master)](https://coveralls.io/github/SimonEnsemble/PorousMaterials.jl?branch=master)
 [![Github All Releases](https://img.shields.io/github/downloads/atom/atom/total.svg)](https://github.com/SimonEnsemble/PorousMaterials.jl)
-[![Twitter URL](https://img.shields.io/twitter/url/http/shields.io.svg?style=social)]( [![Github All Releases](https://img.shields.io/github/downloads/atom/atom/total.svg)](https://github.com/SimonEnsemble/PorousMaterials.jl)) [![Twitter Follow](https://img.shields.io/twitter/follow/espadrine.svg?style=social&label=Follow)](https://github.com/SimonEnsemble/PorousMaterials.jl)
+[![Twitter URL](https://img.shields.io/twitter/url/http/shields.io.svg?style=social)](https://github.com/SimonEnsemble/PorousMaterials.jl) [![Twitter Follow](https://img.shields.io/twitter/follow/espadrine.svg?style=social&label=Follow)](https://github.com/SimonEnsemble/PorousMaterials.jl)
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 ![PorousMaterials.jl](PMlogo.png)
 
 [![Build Status](https://travis-ci.org/SimonEnsemble/PorousMaterials.jl.svg?branch=master)](https://travis-ci.org/SimonEnsemble/PorousMaterials.jl) [![Coverage Status](https://coveralls.io/repos/github/SimonEnsemble/PorousMaterials.jl/badge.svg?branch=master)](https://coveralls.io/github/SimonEnsemble/PorousMaterials.jl?branch=master)
-[![Github All Releases](https://img.shields.io/github/downloads/atom/atom/total.svg)](https://github.com/SimonEnsemble/PorousMaterials.jl)
-[![Twitter URL](https://img.shields.io/twitter/url/http/shields.io.svg?style=social)](https://github.com/SimonEnsemble/PorousMaterials.jl) [![Twitter Follow](https://img.shields.io/twitter/follow/espadrine.svg?style=social&label=Follow)](https://github.com/SimonEnsemble/PorousMaterials.jl)
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 ![PorousMaterials.jl](PMlogo.png)
 
-[![Build Status](https://travis-ci.org/SimonEnsemble/PorousMaterials.jl.svg?branch=master)](https://travis-ci.org/SimonEnsemble/PorousMaterials.jl)    [![Coverage Status](https://coveralls.io/repos/github/SimonEnsemble/PorousMaterials.jl/badge.svg?branch=master)](https://coveralls.io/github/SimonEnsemble/PorousMaterials.jl?branch=master)
+[![Build Status](https://travis-ci.org/SimonEnsemble/PorousMaterials.jl.svg?branch=master)](https://travis-ci.org/SimonEnsemble/PorousMaterials.jl) [![Coverage Status](https://coveralls.io/repos/github/SimonEnsemble/PorousMaterials.jl/badge.svg?branch=master)](https://coveralls.io/github/SimonEnsemble/PorousMaterials.jl?branch=master)
+[![Github All Releases](https://img.shields.io/github/downloads/atom/atom/total.svg)](https://github.com/SimonEnsemble/PorousMaterials.jl)
+[![Twitter URL](https://img.shields.io/twitter/url/http/shields.io.svg?style=social)]( [![Github All Releases](https://img.shields.io/github/downloads/atom/atom/total.svg)](https://github.com/SimonEnsemble/PorousMaterials.jl)) [![Twitter Follow](https://img.shields.io/twitter/follow/espadrine.svg?style=social&label=Follow)](https://github.com/SimonEnsemble/PorousMaterials.jl)
+
+
 
 A pure-[Julia](https://julialang.org/) package for classical molecular modeling of adsorption in porous crystals such as metal-organic frameworks (MOFs).
 

--- a/src/PorousMaterials.jl
+++ b/src/PorousMaterials.jl
@@ -11,7 +11,8 @@ using ProgressMeter
 using JLD
 using Polynomials
 
-
+# this runs everytime PorousMaterials is loaded, so if the user changes directory
+#   then the PATH_TO_DATA will change as well
 function __init__()
     # this is the directory where crystal structures, forcefields, and molecules data is stored
     global PATH_TO_DATA = pwd() * "/data/"

--- a/src/PorousMaterials.jl
+++ b/src/PorousMaterials.jl
@@ -1,3 +1,4 @@
+__precompile__()
 module PorousMaterials
 
 using CSV
@@ -10,8 +11,11 @@ using ProgressMeter
 using JLD
 using Polynomials
 
-# this is the directory where crystal structures, forcefields, and molecules data is stored
-global PATH_TO_DATA = pwd() * "/data/"
+
+function __init__()
+    # this is the directory where crystal structures, forcefields, and molecules data is stored
+    global PATH_TO_DATA = pwd() * "/data/"
+end
 
 include("Box.jl")
 include("Matter.jl")


### PR DESCRIPTION
Compiles many of the statements the first time the package is used. It increases the time to run the first time used, but cuts time for subsequent uses when closing and re-opening the REPL.