### PR TITLE
Flood fill fix

### DIFF
--- a/test/grid_test.jl
+++ b/test/grid_test.jl
@@ -90,6 +90,7 @@ using Random
     accessibility_grid, some_pockets_were_blocked = compute_accessibility_grid(framework, 
         molecule, forcefield, n_pts=(20, 20, 20), energy_tol=0.0, verbose=false, 
         write_b4_after_grids=true)
+
     # replicate framework and build accessibility grid that includes the other accessibility grid in a corner
     repfactors = (2, 3, 1)
     framework = replicate(framework, repfactors)

--- a/test/grid_workup.jl
+++ b/test/grid_workup.jl
@@ -5,10 +5,12 @@ molecule = Molecule("CH4")
 forcefield = LJForceField("UFF.csv")
 grid = energy_grid(framework, molecule, forcefield, n_pts=(20, 20, 20))
 
-segmented_grid = PorousMaterials._segment_grid(grid, energy_tol=0.0, verbose=true)
+segmented_grid = PorousMaterials._segment_grid(grid, 298.0, true)
+verbose = true
 write_cube(segmented_grid, "segmented_grid_LTA_b4.cube")
-graph = PorousMaterials._build_connectivity_graph(segmented_grid)
-segment_classifications = PorousMaterials._classify_segments(segmented_grid, graph)
+connections = PorousMaterials._build_list_of_connections(segmented_grid)
+graph, vertex_to_direction = PorousMaterials._translate_into_graph(segmented_grid, connections)
+segment_classifications = PorousMaterials._classify_segments(segmented_grid, graph, vertex_to_direction, verbose)
 PorousMaterials._assign_inaccessible_pockets_minus_one!(segmented_grid, segment_classifications)
 write_cube(segmented_grid, "segmented_grid_LTA_after.cube")
 

--- a/test/grid_workup.jl
+++ b/test/grid_workup.jl
@@ -1,6 +1,7 @@
 using PorousMaterials
 
 framework = Framework("LTA.cif")
+write_xyz(framework)
 molecule = Molecule("CH4")
 forcefield = LJForceField("UFF.csv")
 grid = energy_grid(framework, molecule, forcefield, n_pts=(20, 20, 20))


### PR DESCRIPTION
The algo to identify segments in the master branch now fails in [this simple case](https://pubs.acs.org/doi/10.1021/ct200787v) in Fig. 1. The reason is that I need to keep track of the which face of the unit cell (e.g. `(1, 0, 0)`) is traversed when one segment is connected to another. In identifying a simple cycle, I then need to walk through that cycle and keep track of which unit cell I'm in. If I arrived back in the home unit cell, that's not accessible. If I arrive in a different unit cell, all segments in that cycle are declared as an accessible channel. Also, if there are any segments connected to this group of segments involved in the cycle, those obviously must be accessible too. So I look for those too.

Tests on LTA and SOD look good.

`LightGraphs.jl` doesn't support edges having properties and being considered as unique acc. to their properties. So I instead made an artificial vertex that includes info about the direction traversed.

So `2 --> 1` with direction `(1, 0, 0)`, I would introduce a new artificial vertex `3` indicating the direction. and make it into `2 --> 3 --> 1`. So when I walk through the cycles, by passing through these artificial vertices, you know what unit cell boundaries you are traversing.

inspired by [here](https://github.com/JuliaGraphs/LightGraphs.jl/issues/1020)