### PR TITLE
Return number of pockets blocked, make inaccessible pocket blocking optional

### DIFF
--- a/src/Grid.jl
+++ b/src/Grid.jl
@@ -536,8 +536,8 @@ to the same segment but in a different unit cell. If any vertex is not involved 
 the segment is declared as inaccessible and all grid points in this segment are re-labeled
 as inaccessible.
 
-Returns `accessibility_grid::Grid{Bool}` and `nb_segments_blocked`, the latter representing
-whether any inaccessible pockets were found.
+Returns `accessibility_grid::Grid{Bool}` and `nb_segments_blocked`, the latter the number
+of segments that were blocked because they were determined to be inaccessible.
 
 # Arguments
 * `framework::Framework`: the crystal for which we seek to compute an accessibility grid.


### PR DESCRIPTION
in `compute_accessibility_grid()`:

- inaccessible pocket blocking is now optional with `block_inaccessible_pockets` flag.
- return the number of segments that were blocked during the procedure instead of just `true` or `false`, since different subsets of inaccessible pockets can be blocked for different gases, this is more informative.

@Surluson you can now speed up your Henry coef calcs to avoid going through the computations that will end up with a huge energy via not blocking pockets but still using an accessibility grid in henry insertions:

```julia
n_pts = required_pts(framework.box, 0.1) # make sure grid resolution is fine, 0.1 A spacing
energy_tol = 15.0 * temperature # block only at really high energy

accessibility_grid, nb_segments_blocked, porosity = compute_accessibility_grid(
      framework, probe_molecule, forcefield, n_pts=n_pts, energy_tol=energy_tol, verbose=false,        
      block_inaccessible_pockets=false, energy_units=:K)

henry_coefficient(..., accessibility_grid=accessibility_grid)
```