### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,9 @@ addons:
             - libhdf5-serial-dev
 sudo: enabled
 after_success:
-    # Allow us to use `Pkg.`
-    - julia -e 'using Pkg'
     # submit data to coveralls
-    - julia -e 'cd(Pkg.dir("PorousMaterials")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder())'
+    - julia -e 'using Pkg; cd(Pkg.dir("PorousMaterials")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder())'
 
     # build the documentation site
-    - julia -e 'Pkg.add("Documenter")'
-    - julia -e 'cd(Pkg.dir("PorousMaterials")); include(joinpath("docs", "make.jl"))'
+    - julia -e 'using Pkg; Pkg.add("Documenter")'
+    - julia -e 'using Pkg; cd(Pkg.dir("PorousMaterials")); include(joinpath("docs", "make.jl"))'

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ addons:
             - libhdf5-serial-dev
 sudo: enabled
 after_success:
+    # Allow us to use `Pkg.`
+    - julia -e 'using Pkg'
     # submit data to coveralls
     - julia -e 'cd(Pkg.dir("PorousMaterials")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder())'
 


### PR DESCRIPTION
I saw an error pop up when looking at the build logs for the documentation pr. It isn't running any of the after success code (coverage, building docs) because it was using `Pkg.` functions. Julia 1.0 needs us to run `using Pkg` in order for these to work. I can check the build logs and make sure it is working successfully after these tests. This might be the issue stopping docs from being made. 