### PR TITLE
changed `nav` to `pages` in mkdocs. Should construct the navbar now

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -30,7 +30,7 @@ extra:
 
 docs_dir: 'build'
 
-nav:
+pages:
   - PorousMaterials: index.md
   - Loading Data: guides/input_files.md
   - Manual:


### PR DESCRIPTION
This should allow us to traverse the site, I think the navbar wasn't showing because Documenter.jl didn't know what was happening in the mkdocs file