### PR TITLE
Removing `target` parameter from the `deploydocs` function in make.jl

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -50,7 +50,7 @@ import PorousMaterials
     deploydocs(
         repo = "github.com/SimonEnsemble/PorousMaterials.jl.git",
         # This is a link to the main repo and the master branch
-        target = "build",
+        # target = "build",
         julia = "1.0",
         osname = "linux",
         deps = Deps.pip("mkdocs", "mkdocs-windmill", "pymdown-extensions") # These are dependencies for the site, not the package


### PR DESCRIPTION
This should fix the issue with the navbar. It wasn't correctly converting the md documentation files into HTML. Now it will correctly add our function docstrings and then convert to HTML and have all of the styling we set up.