### PR TITLE
Take snapshots of molecule positions during GCMC and record adsorbate density grid

### DIFF
--- a/docs/src/manual/boxes_crystals_grids.md
+++ b/docs/src/manual/boxes_crystals_grids.md
@@ -123,6 +123,8 @@ write_cube(grid, "CH4_in_SBMOF1.cube")
 ## Grids
 ```@docs
     Grid
+    xf_to_id
+    update_density!
     apply_periodic_boundary_condition!
     write_cube
     read_cube

--- a/docs/src/manual/molecules.md
+++ b/docs/src/manual/molecules.md
@@ -46,9 +46,11 @@ rotate!(molecule, UnitCube()) # b/c now fractional coords defined in context of 
 ## Molecules
 ```@docs
     Molecule
+    n_atoms
     translate_to!
     rotate!
-    rotation_matrix
+    rotation_matrix()
+    rotation_matrix(::Float64, ::Array{Float64, 1}; ::Bool)
     rand_point_on_unit_sphere
     charged(::Molecule; ::Bool)
 ```

--- a/src/GCMC.jl
+++ b/src/GCMC.jl
@@ -1,4 +1,4 @@
-ileimport Base: +, /
+import Base: +, /
 
 const KB = 1.38064852e7 # Boltmann constant (Pa-m3/K --> Pa-A3/K)
 

--- a/src/GCMC.jl
+++ b/src/GCMC.jl
@@ -190,6 +190,8 @@ function adsorption_isotherm(framework::Framework, molecule::Molecule, temperatu
     ewald_precision::Float64=1e-6, eos::Symbol=:ideal,
     load_checkpoint_file::Bool=false, checkpoint::Dict=Dict(), checkpoint_frequency::Int=50,
     write_checkpoints::Bool=false, show_progress_bar::Bool=false,
+    write_adsorbate_snapshots::Bool=false, snapshot_frequency::Int=1,
+    calculate_density_grid::Bool=false, density_grid_dx::Float64=1.0,
     filename_comment::AbstractString="")
     # make a function of pressure only to facilitate uses of `pmap`
     run_pressure(pressure::Float64) = gcmc_simulation(framework, molecule, temperature,
@@ -203,6 +205,10 @@ function adsorption_isotherm(framework::Framework, molecule::Molecule, temperatu
                                                       checkpoint=checkpoint, checkpoint_frequency=checkpoint_frequency,
                                                       write_checkpoints=write_checkpoints,
                                                       show_progress_bar=show_progress_bar,
+                                                      write_adsorbate_snapshot=write_adsorbate_snapshot,
+                                                      snapshot_frequency=snapshot_frequency,
+                                                      claculate_density_grid=calculate_density_grid,
+                                                      density_grid_dx=density_grid_dx,
                                                       filename_comment=filename_comment)[1] # only return results
 
     # for load balancing, larger pressures with longer computation time goes first

--- a/src/GCMC.jl
+++ b/src/GCMC.jl
@@ -248,7 +248,7 @@ translation.
 - `n_burn_cycles::Int`: number of cycles to allow the system to reach equilibrium before
     sampling.
 - `n_sample_cycles::Int`: number of cycles used for sampling
-- `sample_period::Int`: during the sampling cycles, sample e.g. the number of adsorbed
+- `sample_frequency::Int`: during the sampling cycles, sample e.g. the number of adsorbed
     gas molecules every this number of Markov proposals.
 - `verbose::Bool`: whether or not to print off information during the simulation.
 - `molecules::Array{Molecule, 1}`: a starting configuration of molecules in the framework.
@@ -261,21 +261,21 @@ is ideal gas, where fugacity = pressure.
 - `checkpoint::Dict`: A checkpoint dictionary that will work as a starting configuration for the run.
     The dictionary has to have the following keys: `outer_cycle`, `molecules`, `system_energy`, `current_block`, `gcmc_stats`, `markov_counts`, `markov_chain_time` and `time`. If this argument is used, keep `load_checkpoint_file=false`.
 - `write_checkpoints::Bool`: Will save checkpoints in data/gcmc_checkpoints if this is true.
-- `checkpoint_period::Int`: Will save checkpoint files every `checkpoint_period` cycles.
+- `checkpoint_frequency::Int`: Will save checkpoint files every `checkpoint_frequency` cycles.
 - `write_adsorbate_snapshots::Bool`: Whether the simulation will create and save a snapshot file
-- `snapshot_period::Int`: The number of cycles taken between each snapshot (after burn cycle completion)
+- `snapshot_frequency::Int`: The number of cycles taken between each snapshot (after burn cycle completion)
 - `calculate_density_grid::Bool`: Whether the simulation will keep track of a density grid for adsorbates
 - `density_grid_dx::Float64`: The space between voxels (in Angstroms)
 - `filename_comment::AbstractString`: An optional comment that will be appended to the name of the saved file (if autosaved)
 """
 function gcmc_simulation(framework::Framework, molecule_::Molecule, temperature::Float64,
     pressure::Float64, ljforcefield::LJForceField; n_burn_cycles::Int=5000,
-    n_sample_cycles::Int=5000, sample_period::Int=1, verbose::Bool=true,
+    n_sample_cycles::Int=5000, sample_frequency::Int=1, verbose::Bool=true,
     molecules::Array{Molecule, 1}=Molecule[], ewald_precision::Float64=1e-6,
     eos::Symbol=:ideal, autosave::Bool=true, show_progress_bar::Bool=false,
     load_checkpoint_file::Bool=false, checkpoint::Dict=Dict(),
-    checkpoint_period::Int=100, write_checkpoints::Bool=false,
-    write_adsorbate_snapshots::Bool=false, snapshot_period::Int=1,
+    checkpoint_frequency::Int=100, write_checkpoints::Bool=false,
+    write_adsorbate_snapshots::Bool=false, snapshot_frequency::Int=1,
     calculate_density_grid::Bool=false, density_grid_dx::Float64=1.0,
     filename_comment::AbstractString="")
 
@@ -365,11 +365,11 @@ function gcmc_simulation(framework::Framework, molecule_::Molecule, temperature:
         println("\tTotal number of atoms: ", framework.atoms.n_atoms)
         println("\tTotal number of point charges: ", framework.charges.n_charges)
         if write_adsorbate_snapshots
-            @printf("\tWriting snapshots of adsorption positions every %d cycles (after burn cycles)\n", snapshot_period)
+            @printf("\tWriting snapshots of adsorption positions every %d cycles (after burn cycles)\n", snapshot_frequency)
             @printf("\t\tWriting to file: %s\n", xyz_filename)
         end
         if calculate_density_grid
-            @printf("\tAdsorption spatial probability density grid written with spacing %.3f Angstroms every %d cycles (after burn cycles)\n", density_grid_dx, snapshot_period)
+            @printf("\tAdsorption spatial probability density grid written with spacing %.3f Angstroms every %d cycles (after burn cycles)\n", density_grid_dx, snapshot_frequency)
             @printf("\t\tGrid data stored in array of size: %d by %d by %d\n", n_pts...)
         end
     end
@@ -616,7 +616,7 @@ function gcmc_simulation(framework::Framework, molecule_::Molecule, temperature:
 
             # if we've done all burn cycles, take samples for statistics
             if outer_cycle > n_burn_cycles
-                if markov_chain_time % sample_period == 0
+                if markov_chain_time % sample_frequency == 0
                     gcmc_stats[current_block].n_samples += 1
 
                     gcmc_stats[current_block].n += length(molecules)
@@ -653,7 +653,7 @@ function gcmc_simulation(framework::Framework, molecule_::Molecule, temperature:
         end
 
         # snapshot cycle
-        if (outer_cycle > n_burn_cycles) && (outer_cycle % snapshot_period == 0)
+        if (outer_cycle > n_burn_cycles) && (outer_cycle % snapshot_frequency == 0)
             if write_adsorbate_snapshots
                 # have a '\n' for every new set of atoms, leaves no '\n' at EOF
                 if num_snapshots > 0
@@ -667,7 +667,7 @@ function gcmc_simulation(framework::Framework, molecule_::Molecule, temperature:
             num_snapshots += 1
         end
 
-        if write_checkpoints && (outer_cycle % checkpoint_period == 0)
+        if write_checkpoints && (outer_cycle % checkpoint_frequency == 0)
             checkpoint = Dict("outer_cycle" => outer_cycle,
                               "molecules" => deepcopy(molecules),
                               "system_energy" => system_energy,

--- a/src/GCMC.jl
+++ b/src/GCMC.jl
@@ -205,9 +205,9 @@ function adsorption_isotherm(framework::Framework, molecule::Molecule, temperatu
                                                       checkpoint=checkpoint, checkpoint_frequency=checkpoint_frequency,
                                                       write_checkpoints=write_checkpoints,
                                                       show_progress_bar=show_progress_bar,
-                                                      write_adsorbate_snapshot=write_adsorbate_snapshot,
+                                                      write_adsorbate_snapshots=write_adsorbate_snapshots,
                                                       snapshot_frequency=snapshot_frequency,
-                                                      claculate_density_grid=calculate_density_grid,
+                                                      calculate_density_grid=calculate_density_grid,
                                                       density_grid_dx=density_grid_dx,
                                                       filename_comment=filename_comment)[1] # only return results
 

--- a/src/GCMC.jl
+++ b/src/GCMC.jl
@@ -781,24 +781,6 @@ function gcmc_simulation(framework::Framework, molecule_::Molecule, temperature:
 end # gcmc_simulation
 
 """
-    num_atoms = atoms_in_molecules(molecules)
-
-calculates the total number of atoms in an array of molecules
-
-# Arguments
- - `molecule::Array{Molecule, 1}`: The molecules to count the number of atoms in
-# Returns
- - The total number of atoms in the molecules passed in
-"""
-function atoms_in_molecules(molecules::Array{Molecule, 1})
-    num_atoms = 0;
-    for molecule in molecules
-        num_atoms += molecule.atoms.n_atoms
-    end
-    return num_atoms
-end
-
-"""
     file_save_name = gcmc_result_savename(framework_name, molecule_species,
                                         ljforcefield_name, temperature, pressure,
                                         n_burn_cycles, n_sample_cycles; comment="",
@@ -847,25 +829,6 @@ function gcmc_result_savename(framework_name::AbstractString,
         filename = filename * extension
 
         return filename
-end
-
-"""
-    write_xyz_to_file(molecules, xyz_file)
-
-writes the coordinates of all atoms in molecules to the given xyz_file file object
-passing a file object around is faster for simulation because it can be opened
-once at the beginning of the simulation and closed at the end
-"""
-function write_xyz_to_file(molecules::Array{Molecule, 1}, xyz_file::IOStream)
-    num_atoms = atoms_in_molecules(molecules)
-    @printf(xyz_file, "%s\n\n", num_atoms)
-    for molecule in molecules
-        for i = 1:molecule.atoms.n_atoms
-            @print(xyz_file, "%s %f %f %f\n", molecules.atoms.species[i],
-                    molecules.atoms.xf[1, i], molecules.atoms.xf[2, i], molecules.atoms.xf[3, i])
-        end
-        write(f, "\n")
-    end
 end
 
 function print_results(results::Dict; print_title::Bool=true)

--- a/src/GCMC.jl
+++ b/src/GCMC.jl
@@ -275,7 +275,7 @@ function gcmc_simulation(framework::Framework, molecule_::Molecule, temperature:
     eos::Symbol=:ideal, autosave::Bool=true, show_progress_bar::Bool=false,
     load_checkpoint_file::Bool=false, checkpoint::Dict=Dict(),
     checkpoint_frequency::Int=100, write_checkpoints::Bool=false,
-    write_adosrbate_snapshots::Bool=false, snapshot_frequency::Int=1,
+    write_adsorbate_snapshots::Bool=false, snapshot_frequency::Int=1,
     calculate_density_grid::Bool=false, density_grid_dx::Float64=1.0,
     filename_comment::AbstractString="")
 
@@ -363,6 +363,13 @@ function gcmc_simulation(framework::Framework, molecule_::Molecule, temperature:
         println("\tFramework chemical formula: ", chemical_formula(framework))
         println("\tTotal number of atoms: ", framework.atoms.n_atoms)
         println("\tTotal number of point charges: ", framework.charges.n_charges)
+        if write_adsorbate_snapshots
+            @printf("\tWriting snapshots of adsorption positions every %d cycles (after burn cycles)\n", snapshot_frequency)
+            @printf("\t\tWriting to file: %s\n", xyz_filename)
+        end
+        if calculate_density_grid
+            @printf("\tAdsorption spatial probability density grid written with spacing %.3f Angstroms every %d cycles (after burn cycles)\n", density_grid_dx, snapshot_frequency)
+        end
     end
 
     # TODO: assert center of mass is origin and make rotate! take optional argument to assume com is at origin?

--- a/src/GCMC.jl
+++ b/src/GCMC.jl
@@ -288,12 +288,12 @@ function gcmc_simulation(framework::Framework, molecule_::Molecule, temperature:
         pretty_print(molecule.species, framework.name, temperature, pressure, ljforcefield)
     end
 
-    xyz_snapshot_file = IOStream() # declare a variable outside of scope so we only open a file if we want to snapshot
-
     xyz_filename = gcmc_result_savename(framework.name, molecule.species,
                     ljforcefield.name, temperature, pressure, n_burn_cycles,
                     n_sample_cycles, comment="adsorbate_positions" * filename_comment,
                     extension=".xyz")
+
+    xyz_snapshot_file = IOStream(xyz_filename) # declare a variable outside of scope so we only open a file if we want to snapshot
 
     # Initialize a density grid based on the framework and the passed in density_grid_dx
     # This calculates the n_pts based on the framework

--- a/src/Grid.jl
+++ b/src/Grid.jl
@@ -20,8 +20,8 @@ end
 """
     grid_coordinates = xf_to_id(n_pts, xf)
 
-Takes the fractional coordinates of a point in a unit cell and returns the
-indices for storing that data inside a `Grid` object
+returns the indices of the voxel in which it falls when a unit cube is
+partitioned into a regular grid of `n_pts[1]` by `n_pts[2]` by `n_pts[3]` voxels
 
 # Arguments
  - `n_pts::Tuple{Int, Int, Int}`: The number of points for each axis in the `Grid`
@@ -46,12 +46,12 @@ at the end of the GCMC simulation.
  - `grid::Grid`: the grid to be updated
  - `molecules::Array{Molecule, 1}`: An array of molecules whose positions will
     be added to the grid
- - `species::Symbol`: The species of molecule that can be added to this density grid
+ - `species::Symbol`: The species of atom that can be added to this density grid
 """
 function update_density!(grid::Grid, molecules::Array{Molecule, 1}, species::Symbol)
     for molecule in molecules
-        if species == molecule.species
-            for i = 1:molecule.atoms.n_atoms
+        for i = 1:molecule.atoms.n_atoms
+            if species == molecule.atoms.species[i]
                 grid.data[xf_to_id(grid.n_pts, molecule.atoms.xf[:, i])...] += 1
             end
         end

--- a/src/Grid.jl
+++ b/src/Grid.jl
@@ -30,38 +30,8 @@ indices for storing that data inside a `Grid` object
  - `id::Array{Int, 1}`: The array indices for storing this point in space
 """
 function xf_to_id(n_pts::Tuple{Int, Int, Int}, xf::Array{Float64, 1})
-    return floor.(Int, xf .* n_pts) .+ 1 
-end
-
-"""
-    density_grid = initialize_density_grid(box, dx, units=:Angstroms)
-
-Initializes a density grid for this box given that two points aren't within
-`dx` of each other or have a given number of points. These cannot be used together,
-and have been set up so that if there is a preferred distance, `n_pts` will be 
-calculated from that. Otherwise `set_n_pts` will be used. The `n_pts` defaults to
-(15, 15, 15).
-
-# Arguments
- - `box::Box`: the box the grid will be modelled on
- - `units::Symbol`: The units for measuring this grid
- - `dx::Float64`: The minimum space between grid points
- - `set_n_pts::Tuple{Int, Int, Int}`: The number of points
-# Returns
- - a grid for storing the density grid based on a specific framework
-"""
-function initialize_density_grid(box::Box; units::Symbol=:Angstroms, 
-                    dx::Float64=0.0, set_n_pts::Tuple{Int, Int, Int}=(15, 15, 15))
-    if dx > 0.0 # if user specified the distance between grid points, use it for n_pts
-        n_pts = required_n_pts(box, dx)
-    else # if user didn't specify a dx, will use a preset n_pts, either preset
-            # or user specified
-        n_pts = set_n_pts
-    end
-    data = zeros(n_pts...)
-    grid = Grid(box, n_pts, data, units, [0.0, 0.0, 0.0])
-
-    return grid
+    voxel_id = floor.(Int, xf .* n_pts) .+ 1
+    return voxel_id
 end
 
 """

--- a/src/Grid.jl
+++ b/src/Grid.jl
@@ -30,6 +30,14 @@ partitioned into a regular grid of `n_pts[1]` by `n_pts[2]` by `n_pts[3]` voxels
  - `id::Array{Int, 1}`: The array indices for storing this point in space
 """
 function xf_to_id(n_pts::Tuple{Int, Int, Int}, xf::Array{Float64, 1})
+    # atom positions wrap inside unit cell, to always return indices in range
+    for i in eachindex(xf)
+        @inbounds if xf[i] > 1.1
+            xf[i] -= 1.0
+        elseif xf[i] < 0.0
+            xf[i] += 1.0
+        end
+    end
     voxel_id = floor.(Int, xf .* n_pts) .+ 1
     return voxel_id
 end

--- a/src/Grid.jl
+++ b/src/Grid.jl
@@ -82,7 +82,7 @@ function update_density!(grid::Grid, molecules::Array{Molecule, 1}, species::Sym
     for molecule in molecules
         if species == molecule.species
             for i = 1:molecule.atoms.n_atoms
-                grid.data[xf_to_id(grid.n_pts, molecule[:, i])...]
+                grid.data[xf_to_id(grid.n_pts, molecule.atoms.xf[:, i])...] += 1
             end
         end
     end

--- a/src/Misc.jl
+++ b/src/Misc.jl
@@ -1,4 +1,22 @@
 """
+    num_atoms = atoms_in_molecules(molecules)
+
+calculates the total number of atoms in an array of molecules
+
+# Arguments
+ - `molecule::Array{Molecule, 1}`: The molecules to count the number of atoms in
+# Returns
+ - The total number of atoms in the molecules passed in
+"""
+function atoms_in_molecules(molecules::Array{Molecule, 1})
+    num_atoms = 0;
+    for molecule in molecules
+        num_atoms += molecule.atoms.n_atoms
+    end
+    return num_atoms
+end
+
+"""
     atoms, x = read_xyz(filename)
 
 Return the list of `atoms` (Array{Symbol, 1}) and their Cartesian coordinates
@@ -71,6 +89,25 @@ function write_xyz(atoms::Array{Symbol, 1}, x::Array{Float64, 2},
     end
     close(xyzfile)
     return nothing
+end
+
+"""
+    write_xyz_to_file(molecules, xyz_file)
+
+writes the coordinates of all atoms in molecules to the given xyz_file file object
+passing a file object around is faster for simulation because it can be opened
+once at the beginning of the simulation and closed at the end
+"""
+function write_xyz_to_file(molecules::Array{Molecule, 1}, xyz_file::IOStream)
+    num_atoms = atoms_in_molecules(molecules)
+    @printf(xyz_file, "%s\n\n", num_atoms)
+    for molecule in molecules
+        for i = 1:molecule.atoms.n_atoms
+            @print(xyz_file, "%s %f %f %f\n", molecules.atoms.species[i],
+                    molecules.atoms.xf[1, i], molecules.atoms.xf[2, i], molecules.atoms.xf[3, i])
+        end
+        write(f, "\n")
+    end
 end
 
 """

--- a/src/Misc.jl
+++ b/src/Misc.jl
@@ -1,22 +1,4 @@
 """
-    num_atoms = atoms_in_molecules(molecules)
-
-calculates the total number of atoms in an array of molecules
-
-# Arguments
- - `molecule::Array{Molecule, 1}`: The molecules to count the number of atoms in
-# Returns
- - The total number of atoms in the molecules passed in
-"""
-function atoms_in_molecules(molecules::Array{Molecule, 1})
-    num_atoms = 0;
-    for molecule in molecules
-        num_atoms += molecule.atoms.n_atoms
-    end
-    return num_atoms
-end
-
-"""
     atoms, x = read_xyz(filename)
 
 Return the list of `atoms` (Array{Symbol, 1}) and their Cartesian coordinates
@@ -89,25 +71,6 @@ function write_xyz(atoms::Array{Symbol, 1}, x::Array{Float64, 2},
     end
     close(xyzfile)
     return nothing
-end
-
-"""
-    write_xyz_to_file(molecules, xyz_file)
-
-writes the coordinates of all atoms in molecules to the given xyz_file file object
-passing a file object around is faster for simulation because it can be opened
-once at the beginning of the simulation and closed at the end
-"""
-function write_xyz_to_file(molecules::Array{Molecule, 1}, xyz_file::IOStream)
-    num_atoms = atoms_in_molecules(molecules)
-    @printf(xyz_file, "%s\n\n", num_atoms)
-    for molecule in molecules
-        for i = 1:molecule.atoms.n_atoms
-            @print(xyz_file, "%s %f %f %f\n", molecules.atoms.species[i],
-                    molecules.atoms.xf[1, i], molecules.atoms.xf[2, i], molecules.atoms.xf[3, i])
-        end
-        write(f, "\n")
-    end
 end
 
 """

--- a/src/Molecules.jl
+++ b/src/Molecules.jl
@@ -149,7 +149,7 @@ function set_fractional_coords_to_unit_cube!(molecule::Molecule, box::Box)
 end
 
 """
-    num_atoms = atoms_in_molecules(molecules)
+    num_atoms = n_atoms(molecules)
 
 calculates the total number of atoms in an array of molecules
 
@@ -158,7 +158,7 @@ calculates the total number of atoms in an array of molecules
 # Returns
  - The total number of atoms in the molecules passed in
 """
-function atoms_in_molecules(molecules::Array{Molecule, 1})
+function n_atoms(molecules::Array{Molecule, 1})
     num_atoms = 0;
     for molecule in molecules
         num_atoms += molecule.atoms.n_atoms
@@ -167,14 +167,23 @@ function atoms_in_molecules(molecules::Array{Molecule, 1})
 end
 
 """
-    write_xyz_to_file(molecules, xyz_file)
+    write_xyz(box, molecules, xyz_file)
 
-writes the coordinates of all atoms in molecules to the given xyz_file file object
+Writes the coordinates of all atoms in molecules to the given xyz_file file object
 passing a file object around is faster for simulation because it can be opened
-once at the beginning of the simulation and closed at the end
+once at the beginning of the simulation and closed at the end.
+
+This writes the coordinates of the molecules in cartesian coordinates, so the
+box is needed for the conversion.
+
+# Arguments
+ - `box::Box`: The box the molecules are in, to convert molecule positions
+        to cartesian coordinates
+ - `molecules::Array{Molecule, 1}`: The array of molecules to be written to the file
+ - `xyz_file::IOStream`: The open 'write' file stream the data will be saved to
 """
-function write_xyz_to_file(box::Box, molecules::Array{Molecule, 1}, xyz_file::IOStream)
-    num_atoms = atoms_in_molecules(molecules)
+function write_xyz(box::Box, molecules::Array{Molecule, 1}, xyz_file::IOStream)
+    num_atoms = n_atoms(molecules)
     @printf(xyz_file, "%s\n", num_atoms)
     for molecule in molecules
         for i = 1:molecule.atoms.n_atoms

--- a/src/Molecules.jl
+++ b/src/Molecules.jl
@@ -173,15 +173,15 @@ writes the coordinates of all atoms in molecules to the given xyz_file file obje
 passing a file object around is faster for simulation because it can be opened
 once at the beginning of the simulation and closed at the end
 """
-function write_xyz_to_file(molecules::Array{Molecule, 1}, xyz_file::IOStream)
+function write_xyz_to_file(box::Box, molecules::Array{Molecule, 1}, xyz_file::IOStream)
     num_atoms = atoms_in_molecules(molecules)
-    @printf(xyz_file, "%s\n\n", num_atoms)
+    @printf(xyz_file, "%s\n", num_atoms)
     for molecule in molecules
         for i = 1:molecule.atoms.n_atoms
-            @printf(xyz_file, "%s %f %f %f\n", molecule.atoms.species[i],
-                    molecule.atoms.xf[1, i], molecule.atoms.xf[2, i], molecule.atoms.xf[3, i])
+            cartesian_coords = box.f_to_c * molecule.atoms.xf[:, i]
+            @printf(xyz_file, "\n%s %f %f %f", molecule.atoms.species[i],
+                    cartesian_coords...)
         end
-        write(xyz_file, "\n")
     end
 end
 

--- a/src/Molecules.jl
+++ b/src/Molecules.jl
@@ -149,6 +149,43 @@ function set_fractional_coords_to_unit_cube!(molecule::Molecule, box::Box)
 end
 
 """
+    num_atoms = atoms_in_molecules(molecules)
+
+calculates the total number of atoms in an array of molecules
+
+# Arguments
+ - `molecule::Array{Molecule, 1}`: The molecules to count the number of atoms in
+# Returns
+ - The total number of atoms in the molecules passed in
+"""
+function atoms_in_molecules(molecules::Array{Molecule, 1})
+    num_atoms = 0;
+    for molecule in molecules
+        num_atoms += molecule.atoms.n_atoms
+    end
+    return num_atoms
+end
+
+"""
+    write_xyz_to_file(molecules, xyz_file)
+
+writes the coordinates of all atoms in molecules to the given xyz_file file object
+passing a file object around is faster for simulation because it can be opened
+once at the beginning of the simulation and closed at the end
+"""
+function write_xyz_to_file(molecules::Array{Molecule, 1}, xyz_file::IOStream)
+    num_atoms = atoms_in_molecules(molecules)
+    @printf(xyz_file, "%s\n\n", num_atoms)
+    for molecule in molecules
+        for i = 1:molecule.atoms.n_atoms
+            @printf(xyz_file, "%s %f %f %f\n", molecules.atoms.species[i],
+                    molecules.atoms.xf[1, i], molecules.atoms.xf[2, i], molecules.atoms.xf[3, i])
+        end
+        write(f, "\n")
+    end
+end
+
+"""
     translate_by!(molecule, dxf)
     translate_by!(molecule, dx, box)
 

--- a/src/Molecules.jl
+++ b/src/Molecules.jl
@@ -178,10 +178,10 @@ function write_xyz_to_file(molecules::Array{Molecule, 1}, xyz_file::IOStream)
     @printf(xyz_file, "%s\n\n", num_atoms)
     for molecule in molecules
         for i = 1:molecule.atoms.n_atoms
-            @printf(xyz_file, "%s %f %f %f\n", molecules.atoms.species[i],
-                    molecules.atoms.xf[1, i], molecules.atoms.xf[2, i], molecules.atoms.xf[3, i])
+            @printf(xyz_file, "%s %f %f %f\n", molecule.atoms.species[i],
+                    molecule.atoms.xf[1, i], molecule.atoms.xf[2, i], molecule.atoms.xf[3, i])
         end
-        write(f, "\n")
+        write(xyz_file, "\n")
     end
 end
 

--- a/src/Molecules.jl
+++ b/src/Molecules.jl
@@ -159,7 +159,7 @@ calculates the total number of atoms in an array of molecules
  - The total number of atoms in the molecules passed in
 """
 function n_atoms(molecules::Array{Molecule, 1})
-    num_atoms = 0;
+    num_atoms = 0
     for molecule in molecules
         num_atoms += molecule.atoms.n_atoms
     end

--- a/src/PorousMaterials.jl
+++ b/src/PorousMaterials.jl
@@ -137,7 +137,7 @@ export
     # Grid.jl
     apply_periodic_boundary_condition!,
     Grid, write_cube, read_cube, energy_grid, compute_accessibility_grid, accessible,
-    required_n_pts, initialize_density_grid, update_density!
+    required_n_pts, initialize_density_grid, update_density!,
 
     # EOS.jl
     calculate_properties, PengRobinsonGas,

--- a/src/PorousMaterials.jl
+++ b/src/PorousMaterials.jl
@@ -137,7 +137,7 @@ export
     # Grid.jl
     apply_periodic_boundary_condition!,
     Grid, write_cube, read_cube, energy_grid, compute_accessibility_grid, accessible,
-    required_n_pts,
+    required_n_pts, initialize_density_grid, update_density!
 
     # EOS.jl
     calculate_properties, PengRobinsonGas,

--- a/src/PorousMaterials.jl
+++ b/src/PorousMaterials.jl
@@ -137,7 +137,7 @@ export
     # Grid.jl
     apply_periodic_boundary_condition!,
     Grid, write_cube, read_cube, energy_grid, compute_accessibility_grid, accessible,
-    required_n_pts, initialize_density_grid, update_density!,
+    required_n_pts, xf_to_id, update_density!,
 
     # EOS.jl
     calculate_properties, PengRobinsonGas,

--- a/src/PorousMaterials.jl
+++ b/src/PorousMaterials.jl
@@ -114,9 +114,10 @@ export
     construct_box, replicate, read_atomic_masses, charged, write_cif, assign_charges,
 
     # Molecules.jl
-    Molecule, set_fractional_coords!, translate_by!, outside_box, set_fractional_coords_to_unit_cube!,
-    translate_to!, rotate!, rotation_matrix, rand_point_on_unit_sphere, charged,
-    pairwise_atom_distances, pairwise_charge_distances, Ion, bond_length_drift,
+    Molecule, n_atoms, set_fractional_coords!, translate_by!, outside_box,
+    set_fractional_coords_to_unit_cube!, translate_to!, rotate!, rotation_matrix,
+    rand_point_on_unit_sphere, charged, pairwise_atom_distances,
+    pairwise_charge_distances, Ion, bond_length_drift,
 
     # Forcefield.jl
     LJForceField, replication_factors, check_forcefield_coverage,

--- a/test/gcmc_checkpoints_test.jl
+++ b/test/gcmc_checkpoints_test.jl
@@ -32,7 +32,7 @@ using Random
         else
             Core.eval(Main, :(import PorousMaterials)) # used to be able to load in objects from Porous Materials
             # This was found here: https://github.com/JuliaIO/JLD.jl/issues/216
-            @load (joinpath(PorousMaterials.PATH_TO_DATA, "gcmc_checkpoints", gcmc_result_savename(framework.name, co2.species, ljff.name, temp, pressure, 5, 5 * i, comment = "_checkpoint"))) checkpoint
+            @load (joinpath(PorousMaterials.PATH_TO_DATA, "gcmc_checkpoints", gcmc_result_savename(framework.name, co2.species, ljff.name, temp, pressure, 5, 5 * i, comment = "_checkpoint", extension=".jld2"))) checkpoint
         end
         results, molecules = gcmc_simulation(framework, deepcopy(co2), temp, pressure, ljff,
                                              n_burn_cycles=5, n_sample_cycles=5 * (i + 1),

--- a/test/grid_test.jl
+++ b/test/grid_test.jl
@@ -147,5 +147,19 @@ using Random
     n_pts = (4, 4, 4) # testing a grid with 4x4x4 voxels
     @test all(xf_to_id(n_pts, [0.0001, 0.0001, 0.0001]) .== 1)
     @test all(xf_to_id(n_pts, [0.9999, 0.9999, 0.9999]) .== n_pts[end])
+    @test all(xf_to_id(n_pts, [0.0001, 0.2400, 0.2600]) .== [1, 1, 2]) 
+
+    # test update_density!
+    unit_box = UnitCube()
+    density_grid_c_co2 = Grid(unit_box, n_pts, zeros(n_pts...), :invers_A3, [0.0, 0.0, 0.0])
+    density_grid_o_co2 = Grid(unit_box, n_pts, zeros(n_pts...), :invers_A3, [0.0, 0.0, 0.0])
+    molecule = Molecule("CO2")
+    translate_to!(molecule, [0.24, 0.26, 0.99])
+    update_density!(density_grid_c_co2, [molecule], :C_CO2) # only updates for a single atom
+    @test isapprox(sum(density_grid_c_co2.data), 1.0)
+    @test isapprox(density_grid_c_co2.data[1, 2, 4], 1.0)
+
+    update_density!(density_grid_o_co2, [molecule], :O_CO2) # only updates for a single atom
+    @test isapprox(sum(density_grid_o_co2.data), 2.0)
 end
 end

--- a/test/grid_test.jl
+++ b/test/grid_test.jl
@@ -142,5 +142,10 @@ using Random
         @test nb_segments_blocked_nb == 0
         @test isapprox(accessibility_grid, accessibility_grid_nb)
     end
+
+    # test xf_to_id
+    n_pts = (4, 4, 4) # testing a grid with 4x4x4 voxels
+    @test all(xf_to_id(n_pts, [0.0001, 0.0001, 0.0001]) .== 1)
+    @test all(xf_to_id(n_pts, [0.9999, 0.9999, 0.9999]) .== n_pts[end])
 end
 end


### PR DESCRIPTION
@ahyork 

Looks great! Before merging this PR:
* add to documentation the new optional arguments to `gcmc_simulation()`
* `snapshots` to more informative `write_adsorbate_snapshots` since now it is only writing them to file.
* `xyz_snapshot_file = ""` is initialized as a string. Doesn't that introduce type instability? Does `xyz_snapshot_file = IOStream` work better, initializing an empty IOStream?
* `comment=filename_comment * "adsorbate_positions"` switch order so comment is always at end.
* " with each point being 0.1 units apart." not true anymore
* `if (outer_cycle % snapshot_frequency == 0) && (outer_cycle > n_burn_cycles)` for speed is it better to reverse these? I imagine `>` is faster than a `%`?
* `write_xyz_to_file` can you change to `write_xyz` to be consistent with the other `write_xyz`? i.e. overload it so one less function name to remember. 
* Make `snapshot_frequency=1` by default.
* "- `snapshot::Bool`: Whether this is the name for a snapshot file" is a vestige of an old version of `gcmc_result_savename`?
* "Takes the fractional coordinates of a point in a unit cell and returns the
indices for storing that data inside a `Grid` object" to be more specific, change to: "returns the indices of the voxel in which it falls when a unit cube is partitioned into a regular grid of `n_pts[1]` by `n_pts[2]` by `n_pts[3]` voxels.
* `write_xyz_to_file(molecules, xyz_file)` doc string does not match function. specify in doc string it is writing cartesian not fractional
* `atoms_in_molecules` is redundant given type assertion, how about `n_atoms(molecules::Array{Molecules})`?
* in `update_density!`, the problem here is that for CO2, it would increment the voxel for both C and O then you'd get a density grid that is confusingly keeping track of C and O. I think we should put the `species` granularity on the atom *within* the molecule (not the molecule itself), so e.g. the user would pass `:C` to keep track of `:C` within CO2.  so `if molecule.atoms.species[i] == species` I think should be the condition for writing