### PR TITLE
Drop Testing for Julia 0.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: julia
 julia:
-- 0.7
 - 1.0
+- 1.1
 addons:
   apt:
     packages:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.7
+julia 1.0
 SpecialFunctions
 OffsetArrays
 Roots

--- a/data/PengRobinson_fluid_props.csv
+++ b/data/PengRobinson_fluid_props.csv
@@ -1,4 +1,4 @@
-gas,Tc(K),Pc(bar),acentric_factor
+fluid,Tc(K),Pc(bar),acentric_factor
 Ar,150.86,48.98,-0.002
 C2H4,282.34,50.41,0.087
 CO2,304.12,73.74,0.225

--- a/data/VdW_fluid_props.csv
+++ b/data/VdW_fluid_props.csv
@@ -1,0 +1,12 @@
+fluid,a(bar*m^6/mol^2),b(m^3/mol)
+Ar,0.000001355,0.0000320
+C2H4,0.000004612,0.0000582
+CO2,0.000003658,0.0000429
+CO,0.000001472,0.0000395
+CH4,0.000002303,0.0000431
+H2,0.0000002452,0.0000265
+Kr,0.000005193,0.0000106
+Xe,0.000004192,0.0000516
+  Values converted and taken from a more complete list given in (do not delete)
+  Reid, R.C, Prausnitz, J. M., and Poling, B.E., The Properties of (do not delete)
+  Gases and Liquids, Fourth Edition, McGraw-Hill, New York, 1987. (do not delete)

--- a/src/EOS.jl
+++ b/src/EOS.jl
@@ -1,13 +1,13 @@
-# Calculates the properties of a real gas, such as the compressibility factor, fugacity,
+# Calculates the properties of a real fluid, such as the compressibility factor, fugacity,
 #   and molar volume.
 
-# Universal gas constant (R). units: m³-bar/(K-mol)
+# Universal fluid constant (R). units: m³-bar/(K-mol)
 const R = 8.3144598e-5
 
-# Data structure stating characteristics of a Peng-Robinson gas
-struct PengRobinsonGas
-    "Peng-Robinson Gas species. e.g. :CO2"
-    gas::Symbol
+# Data structure stating characteristics of a Peng-Robinson fluid
+struct PengRobinsonFluid
+    "Peng-Robinson Fluid species. e.g. :CO2"
+    fluid::Symbol
     "Critical temperature (units: Kelvin)"
     Tc::Float64
     "Critical pressure (units: bar)"
@@ -16,23 +16,25 @@ struct PengRobinsonGas
     ω::Float64
 end
 
+# Data structure stating
+
 # Parameters in the Peng-Robinson Equation of State
 # T in Kelvin, P in bar
-a(gas::PengRobinsonGas) = (0.457235 * R ^ 2 * gas.Tc ^ 2) / gas.Pc
-b(gas::PengRobinsonGas) = (0.0777961 * R * gas.Tc) / gas.Pc
-κ(gas::PengRobinsonGas) = 0.37464 + (1.54226 * gas.ω) - (0.26992 * gas.ω ^ 2)
+a(fluid::PengRobinsonFluid) = (0.457235 * R ^ 2 * fluid.Tc ^ 2) / fluid.Pc
+b(fluid::PengRobinsonFluid) = (0.0777961 * R * fluid.Tc) / fluid.Pc
+κ(fluid::PengRobinsonFluid) = 0.37464 + (1.54226 * fluid.ω) - (0.26992 * fluid.ω ^ 2)
 α(κ::Float64, Tr::Float64) = (1 + κ * (1 - √Tr)) ^ 2
-A(T::Float64, P::Float64, gas::PengRobinsonGas) = α(κ(gas), T / gas.Tc) * a(gas) * P / (R ^ 2 * T ^ 2)
-B(T::Float64, P::Float64, gas::PengRobinsonGas) = b(gas) * P / (R * T)
+A(T::Float64, P::Float64, fluid::PengRobinsonFluid) = α(κ(fluid), T / fluid.Tc) * a(fluid) * P / (R ^ 2 * T ^ 2)
+B(T::Float64, P::Float64, fluid::PengRobinsonFluid) = b(fluid) * P / (R * T)
 
 # Calculates three outputs for compressibility factor using the polynomial form of
 # the Peng-Robinson Equation of State. Filters for only real roots and returns the
 # root closest to unity.
-function compressibility_factor(gas::PengRobinsonGas, T::Float64, P::Float64)
+function compressibility_factor(fluid::PengRobinsonFluid, T::Float64, P::Float64)
     # construct cubic polynomial in z
-    p = Poly([-(A(T, P, gas) * B(T, P, gas) - B(T, P, gas) ^ 2 - B(T, P, gas) ^ 3),
-              A(T, P, gas) - 2 * B(T, P, gas) - 3 * B(T, P, gas) ^ 2,
-              -(1.0 - B(T, P, gas)),
+    p = Poly([-(A(T, P, fluid) * B(T, P, fluid) - B(T, P, fluid) ^ 2 - B(T, P, fluid) ^ 3),
+              A(T, P, fluid) - 2 * B(T, P, fluid) - 3 * B(T, P, fluid) ^ 2,
+              -(1.0 - B(T, P, fluid)),
               1.0])
     # solve for the roots of the cubic polynomial
     z_roots = roots(p)
@@ -45,45 +47,45 @@ function compressibility_factor(gas::PengRobinsonGas, T::Float64, P::Float64)
 end
 
 # Calculating for fugacity coefficient from an integration (bar).
-function calculate_ϕ(gas::PengRobinsonGas, T::Float64, P::Float64)
-    z = compressibility_factor(gas, T, P)
-    log_ϕ = z - 1.0 - log(z - B(T, P, gas)) +
-            - A(T, P, gas) / (√8 * B(T, P, gas)) * log(
-            (z + (1 + √2) * B(T, P, gas)) / (z + (1 - √(2)) * B(T, P, gas)))
+function calculate_ϕ(fluid::PengRobinsonFluid, T::Float64, P::Float64)
+    z = compressibility_factor(fluid, T, P)
+    log_ϕ = z - 1.0 - log(z - B(T, P, fluid)) +
+            - A(T, P, fluid) / (√8 * B(T, P, fluid)) * log(
+            (z + (1 + √2) * B(T, P, fluid)) / (z + (1 - √(2)) * B(T, P, fluid)))
     return exp(log_ϕ)
 end
 
 """
-    props = calculate_properties(gas, T, P, verbose=true)
+    props = calculate_properties(fluid, T, P, verbose=true)
 
-Use equation of state to calculate density, fugacity, and molar volume of a real gas at a
+Use equation of state to calculate density, fugacity, and molar volume of a real fluid at a
 given temperature and pressure.
 
 # Arguments
-- `gas::PengRobinsonGas`: Peng-Robinson gas data structure
+- `fluid::PengRobinsonFluid`: Peng-Robinson fluid data structure
 - `T::Float64`: Temperature (units: Kelvin)
 - `P::Float64`: Pressure (units: bar)
 - `verbose::Bool`: will print results if `true`
 
 # Returns
-- `prop_dict::Dict`: Dictionary of Peng-Robinson gas properties
+- `prop_dict::Dict`: Dictionary of Peng-Robinson fluid properties
 """
-function calculate_properties(gas::PengRobinsonGas, T::Float64, P::Float64; verbose::Bool=true)
+function calculate_properties(fluid::PengRobinsonFluid, T::Float64, P::Float64; verbose::Bool=true)
     # Compressbility factor (unitless)
-    z = compressibility_factor(gas, T, P)
+    z = compressibility_factor(fluid, T, P)
     # Density (mol/m^3)
     ρ = P / (z * R * T)
     # Molar volume (L/mol)
     Vm = 1.0 / ρ * 1000.0
     # Fugacity (bar)
-    ϕ = calculate_ϕ(gas, T, P)
+    ϕ = calculate_ϕ(fluid, T, P)
     f = ϕ * P
     # Prints a dictionary holding values for compressibility factor, molar volume, density, and fugacity.
     prop_dict = Dict("compressibility factor" => z, "molar volume (L/mol)"=> Vm ,
                      "density (mol/m³)" => ρ, "fugacity (bar)" => f,
                      "fugacity coefficient" => ϕ)
     if verbose
-        @printf("%s properties at T = %f K, P = %f bar:\n", gas.gas, T, P)
+        @printf("%s properties at T = %f K, P = %f bar:\n", fluid.fluid, T, P)
         for (property, value) in prop_dict
             println("\t" * property * ": ", value)
         end
@@ -93,34 +95,34 @@ end
 
 
 """
-    gas = PengRobinsonGas(gas)
+    fluid = PengRobinsonFluid(fluid)
 
-Reads in critical temperature, critical pressure, and acentric factor of the `gas::Symbol`
-from the properties .csv file `joinpath(PorousMaterials.PATH_TO_DATA, "PengRobinsonGasProps.csv")`
-and returns a complete `PengRobinsonGas` data structure.
-**NOTE: Do not delete the last three comment lines in PengRobinsonGasProps.csv
+Reads in critical temperature, critical pressure, and acentric factor of the `fluid::Symbol`
+from the properties .csv file `joinpath(PorousMaterials.PATH_TO_DATA, "PengRobinsonFluidProps.csv")`
+and returns a complete `PengRobinsonFluid` data structure.
+**NOTE: Do not delete the last three comment lines in PengRobinsonFluidProps.csv
 
 # Arguments
-- `gas::Symbol`: The gas molecule you wish to construct a PengRobinsonGas struct for
+- `fluid::Symbol`: The fluid molecule you wish to construct a PengRobinsonFluid struct for
 
 # Returns
-- `PengRobinsonGas::struct`: Data structure containing Peng-Robinson gas parameters.
+- `PengRobinsonFluid::struct`: Data structure containing Peng-Robinson fluid parameters.
 """
-function PengRobinsonGas(gas::Symbol)
-    df = CSV.read(joinpath(PATH_TO_DATA, "PengRobinsonGasProps.csv"); footerskip=3)
-    if ! (string(gas) in df[:gas])
-        error(@sprintf("Gas %s properties not found in %sPengRobinsonGasProps.csv", gas, PATH_TO_DATA))
+function PengRobinsonFluid(fluid::Symbol)
+    df = CSV.read(joinpath(PATH_TO_DATA, "PengRobinsonFluidProps.csv"); footerskip=3)
+    if ! (string(fluid) in df[:fluid])
+        error(@sprintf("fluid %s properties not found in %sPengRobinsonFluidProps.csv", fluid, PATH_TO_DATA))
     end
-    Tc = df[df[:gas].== string(gas), Symbol("Tc(K)")][1]
-    Pc = df[df[:gas].== string(gas), Symbol("Pc(bar)")][1]
-    ω = df[df[:gas].== string(gas), Symbol("acentric_factor")][1]
-    return PengRobinsonGas(gas, Tc, Pc, ω)
+    Tc = df[df[:fluid].== string(fluid), Symbol("Tc(K)")][1]
+    Pc = df[df[:fluid].== string(fluid), Symbol("Pc(bar)")][1]
+    ω = df[df[:fluid].== string(fluid), Symbol("acentric_factor")][1]
+    return PengRobinsonFluid(fluid, Tc, Pc, ω)
 end
 
-# Prints resulting values for Peng-Robinson gas properties
-function Base.show(io::IO, gas::PengRobinsonGas)
-    println(io, "Gas species: ", gas.gas)
-    println(io, "\tCritical temperature (K): ", gas.Tc)
-    println(io, "\tCritical pressure (bar): ", gas.Pc)
-    println(io, "\tAcenteric factor: ", gas.ω)
+# Prints resulting values for Peng-Robinson fluid properties
+function Base.show(io::IO, fluid::PengRobinsonFluid)
+    println(io, "fluid species: ", fluid.fluid)
+    println(io, "\tCritical temperature (K): ", fluid.Tc)
+    println(io, "\tCritical pressure (bar): ", fluid.Pc)
+    println(io, "\tAcenteric factor: ", fluid.ω)
 end

--- a/src/EOS.jl
+++ b/src/EOS.jl
@@ -96,9 +96,9 @@ end
     fluid = PengRobinsonFluid(fluid)
 
 Reads in critical temperature, critical pressure, and acentric factor of the `fluid::Symbol`
-from the properties .csv file `joinpath(PorousMaterials.PATH_TO_DATA, "PengRobinsonFluidProps.csv")`
+from the properties .csv file `joinpath(PorousMaterials.PATH_TO_DATA, "PengRobinson_fluid_props.csv")`
 and returns a complete `PengRobinsonFluid` data structure.
-**NOTE: Do not delete the last three comment lines in PengRobinsonFluidProps.csv
+**NOTE: Do not delete the last three comment lines in PengRobinson_fluid_props.csv
 
 # Arguments
 - `fluid::Symbol`: The fluid molecule you wish to construct a PengRobinsonFluid struct for
@@ -107,9 +107,9 @@ and returns a complete `PengRobinsonFluid` data structure.
 - `PengRobinsonFluid::struct`: Data structure containing Peng-Robinson fluid parameters.
 """
 function PengRobinsonFluid(fluid::Symbol)
-    df = CSV.read(joinpath(PATH_TO_DATA, "PengRobinsonfluidProps.csv"); footerskip=3)
+    df = CSV.read(joinpath(PATH_TO_DATA, "PengRobinson_fluid_props.csv"); footerskip=3)
     if ! (string(fluid) in df[:fluid])
-        error(@sprintf("fluid %s properties not found in %sPengRobinsonFluidProps.csv", fluid, PATH_TO_DATA))
+        error(@sprintf("fluid %s properties not found in %sPengRobinson_fluid_props.csv", fluid, PATH_TO_DATA))
     end
     Tc = df[df[:fluid].== string(fluid), Symbol("Tc(K)")][1]
     Pc = df[df[:fluid].== string(fluid), Symbol("Pc(bar)")][1]

--- a/src/PorousMaterials.jl
+++ b/src/PorousMaterials.jl
@@ -142,7 +142,7 @@ export
     required_n_pts, xf_to_id, id_to_xf, update_density!,
 
     # EOS.jl
-    calculate_properties, PengRobinsonGas,
+    calculate_properties, PengRobinsonFluid, VdWFluid,
 
     # GCMC.jl
     gcmc_simulation, adsorption_isotherm, stepwise_adsorption_isotherm,

--- a/test/data/PengRobinson_fluid_props.csv
+++ b/test/data/PengRobinson_fluid_props.csv
@@ -7,6 +7,3 @@ CH4,190.56,45.99,0.011
 H2,32.98,12.93,-0.217
 Kr,209.40,55.00,0.005
 Xe,289.74,58.40,0.008
- Values taken from a more complete list given in (do not delete)
- R. C. Reid, J. M. Prausnitz, and B. E. Poling, 2001, (do not delete)
- The Properties of Gases and Liquids, 5th Ed. New York: McGraw-Hill. (do not delete)

--- a/test/data/PengRobinson_fluid_props.csv
+++ b/test/data/PengRobinson_fluid_props.csv
@@ -1,4 +1,4 @@
-gas,Tc(K),Pc(bar),acentric_factor
+fluid,Tc(K),Pc(bar),acentric_factor
 Ar,150.86,48.98,-0.002
 C2H4,282.34,50.41,0.087
 CO2,304.12,73.74,0.225

--- a/test/eos_test.jl
+++ b/test/eos_test.jl
@@ -10,7 +10,7 @@ using Random
 
 @testset "EOS Tests" begin
     # Peng-Robinsion EOS test for methane.
-    gas = PengRobinsonGas(:CH4)
+    gas = PengRobinsonFluid(:CH4)
     props = calculate_properties(gas, 298.0, 65.0, verbose=false)
     @test isapprox(props["compressibility factor"], 0.874496226625811, atol=1e-4)
     @test isapprox(props["fugacity coefficient"], 0.8729028157628362, atol=1e-4)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,7 @@
 # Details from http://www.stochasticlifestyle.com/finalizing-julia-package-documentation-testing-coverage-publishing/
+# Values for PengRobinson taken from a more complete list given in (do not delete)
+# R. C. Reid, J. M. Prausnitz, and B. E. Poling, 2001, (do not delete)
+# The Properties of Gases and Liquids, 5th Ed. New York: McGraw-Hill. (do not delete)
 # Start Test Script
 
 include("box_test.jl")


### PR DESCRIPTION
No longer tests against Julia 0.7, minimum required to run PorousMaterials is Julia 1.0

Wait to merge this until EOS_revise is merged and all tests pass