### PR TITLE
Fix dataframe mutation

### DIFF
--- a/src/Misc.jl
+++ b/src/Misc.jl
@@ -189,10 +189,10 @@ where N is the total adsorption, M is the maximum monolayer coverage, K is the L
 """
 function fit_adsorption_isotherm(df::DataFrame, pressure_col_name::Symbol, 
                                  loading_col_name::Symbol, model::Symbol)
-    sort!(df, [pressure_col_name])
-    n = df[!, loading_col_name]
-    p = df[!, pressure_col_name]
-    θ0 = _guess(df, pressure_col_name, loading_col_name, model)
+    _df = sort(df, [pressure_col_name])
+    n = _df[!, loading_col_name]
+    p = _df[!, pressure_col_name]
+    θ0 = _guess(_df, pressure_col_name, loading_col_name, model)
 
     if model == :langmuir
         objective_function_langmuir(θ) = return sum([(n[i] - θ[1] * θ[2] * p[i] / (1 + θ[2] * p[i]))^2 for i = 1:length(n)])

--- a/test/misc_test.jl
+++ b/test/misc_test.jl
@@ -29,7 +29,7 @@ using Random
     @test isapprox(M, M_opt, rtol=1e-6)
     @test isapprox(K, K_opt, rtol=1e-6)
 
-    df = CSV.read("Ni-MOF-74_isotherm_test.csv", copycols=true)
+    df = CSV.read("Ni-MOF-74_isotherm_test.csv")
     x = fit_adsorption_isotherm(df, Symbol("P(bar)"), Symbol("mol_m3"), :langmuir)
     M_opt, K_opt = x["M"], x["K"]
     @test isapprox(M_opt, 8546.37534030619, atol=1e-5)


### PR DESCRIPTION
Previous version assumed the DataFrame being read in was mutable.
This fix removes that assumption by changing the `sort!` function into `sort` (so the input argument doesn't get modified).

The tests have also been slightly modified to deal with immutable DataFrames.