### PR TITLE
Add option to add Optim options to optimization functions

### DIFF
--- a/test/misc_test.jl
+++ b/test/misc_test.jl
@@ -15,6 +15,8 @@ using Random
     df = DataFrame(P = [0.0, 0.56, 1.333], N = [0.0, 0.534, 1.295])
     henry = fit_adsorption_isotherm(df, :P, :N, :henry)["H"]
     @test isapprox(henry, 0.9688044280548711)
+    henry = fit_adsorption_isotherm(df, :P, :N, :henry, Optim.Options(iterations=100))["H"]
+    @test isapprox(henry, 0.9688044280548711)
     
     # Langmuir
     P = range(0, stop=1, length=100)


### PR DESCRIPTION
Add the option to use Optim.jl options during optimization process.

Defaults to regular behavior (`Optim.Options()` gives the unmodified options) but you can change the options by e.g. `options=Optim.Options(iterations = 10)` if you only want to allow 10 iterations.

List of arguments you can use in `Optim.Options` can be found here: https://julianlsolvers.github.io/Optim.jl/stable/#user/config/#configurable-options