### PR TITLE
Added grids page to the docs builder

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -16,7 +16,8 @@ makedocs(
             "forcefields" => "force_field.md",
             "equations of state" => "eos.md",
             "Henry coefficients" => "henry.md",
-            "grand-canonical Monte Carlo simulations" => "gcmc.md"
+            "grand-canonical Monte Carlo simulations" => "gcmc.md",
+            "grids" => "grid.md"
             ],
     format = Documenter.HTML(assets = ["assets/flux.css"])
 )


### PR DESCRIPTION
The `grid.md` file already existed, but it wasn't being built.

Fixes #162 