### PR TITLE
refactored grid functions to take grid_dx input instead of n_pts

### DIFF
--- a/src/grid.jl
+++ b/src/grid.jl
@@ -56,7 +56,7 @@ corresponds.
 """
 function id_to_xf(id::Tuple{Int, Int, Int}, n_pts::Tuple{Int, Int, Int})
     return [(id[k] - 1.0) / (n_pts[k] - 1.0) for k = 1:3]
-end 
+end
 
 """
     update_density!(grid, molecule, species)
@@ -243,7 +243,7 @@ function read_cube(filename::AbstractString)
 end
 
 """
-	grid = energy_grid(crystal, molecule, ljforcefield; n_pts=(50, 50, 50), temperature=298.0, n_rotations=750)
+	grid = energy_grid(crystal, molecule, ljforcefield; grid_dx=1.0, temperature=298.0, n_rotations=750)
 
 Superimposes a regular grid of points (regularly spaced in fractional coordinates of the `crystal.box`) over the unit cell of a crystal, with `n_gridpts` dictating the number of grid points in the a, b, c directions (including 0 and 1 fractional coords).
 The fractional coordinates 0 and 1 are included in the grid, although they are redundant.
@@ -255,7 +255,7 @@ The ensemble average is a Boltzmann average over rotations:  - R T log ⟨e⁻�
 - `crystal::Crystal`: crystal in which we seek to compute an energy grid for a molecule. `grid.box` will be `framework.box`.
 - `molecule::Molecule`: molecule for which we seek an energy grid
 - `ljforcefield::LJForceField`: molecular model for computing molecule-crystal interactions
-- `n_pts::Tuple{Int, Int, Int}=(50,50,50)`: number of grid points in each fractional coordinate dimension, including endpoints (0, 1)
+- `grid_dx::Float=1.0`: maximum distance between grid points, in Å
 - `n_rotations::Int`: number of random rotations to conduct in a Monte Carlo simulation for finding the free energy of a molecule centered at a given grid point.
 This is only relevant for molecules that are comprised of more than one Lennard Jones sphere.
 - `temperature::Float64`: the temperature at which to compute the free energy for molecules where rotations are required. Lower temperatures overemphasize the minimum potential energy rotational conformation at that point.
@@ -267,13 +267,15 @@ This is only relevant for molecules that are comprised of more than one Lennard 
 - `grid::Grid`: A grid data structure containing the potential energy of the system
 """
 function energy_grid(crystal::Crystal, molecule::Molecule{Cart}, ljforcefield::LJForceField;
-                     n_pts::Tuple{Int, Int, Int}=(50,50,50), n_rotations::Int=1000, 
+                     grid_dx::Float64=1.0, n_rotations::Int=1000,
                      temperature::Float64=NaN, units::Symbol=:kJ_mol, center::Bool=false,
                      verbose::Bool=true)
     assert_P1_symmetry(crystal)
     if ! (units in [:kJ_mol, :K])
         error("Pass :kJ_mol or :K for units of kJ/mol or K, respectively.")
     end
+
+    n_pts = required_n_pts(crystal.box, grid_dx)
 
     rotations_required = needs_rotations(molecule)
     charged_system = has_charges(crystal) && has_charges(molecule)
@@ -288,7 +290,7 @@ function energy_grid(crystal::Crystal, molecule::Molecule{Cart}, ljforcefield::L
     # grid of voxel centers (each axis at least).
     grid_pts = [collect(range(0.0; stop=1.0, length=n_pts[i])) for i = 1:3]
 
-    grid = Grid(crystal.box, n_pts, zeros(Float64, n_pts...), units, 
+    grid = Grid(crystal.box, n_pts, zeros(Float64, n_pts...), units,
         center ? crystal.box.f_to_c * [-0.5, -0.5, -0.5] : [0.0, 0.0, 0.0])
 
     if verbose
@@ -302,7 +304,7 @@ function energy_grid(crystal::Crystal, molecule::Molecule{Cart}, ljforcefield::L
     # convert molecule to frac coords *before* replicating.
     # (don't need grid to be size of replicated xtal)
     molecule = Frac(molecule, crystal.box)
-    
+
     # compute replication factors required for short-range interactions & cutoff
     repfactors = replication_factors(crystal.box, ljforcefield)
     crystal = replicate(crystal, repfactors)
@@ -320,7 +322,7 @@ function energy_grid(crystal::Crystal, molecule::Molecule{Cart}, ljforcefield::L
                 energy = PotentialEnergy(0.0, 0.0)
                 energy.vdw = vdw_energy(crystal, molecule, ljforcefield)
                 if charged_system
-                    energy.coulomb = total(electrostatic_potential_energy(crystal, molecule, 
+                    energy.coulomb = total(electrostatic_potential_energy(crystal, molecule,
                                                                          eparams, eikr))
                 end
                 boltzmann_factor_sum += exp(-sum(energy) / temperature)
@@ -353,7 +355,7 @@ function Base.isapprox(g1::Grid, g2::Grid; atol::Real=0.0, rtol::Real=atol > 0.0
             isapprox(g1.origin, g2.origin, atol=atol, rtol=rtol))
 end
 
-function _flood_fill!(grid::Grid, segmented_grid::Grid, 
+function _flood_fill!(grid::Grid, segmented_grid::Grid,
             queue_of_grid_pts::Array{Tuple{Int, Int, Int}, 1},
             i::Int, j::Int, k::Int, energy_tol::Float64)
     # look left, right, up, down "_s" for shift
@@ -362,10 +364,10 @@ function _flood_fill!(grid::Grid, segmented_grid::Grid,
         if (i_s, j_s, k_s) == (0, 0, 0)
             continue
         end
-        
+
         # index of a neighboring point
         ind = (i + i_s, j + j_s, k + k_s)
-        
+
         # avoid out of bounds
         if any(ind .<= (0, 0, 0)) || any(ind .> grid.n_pts)
             continue
@@ -398,7 +400,7 @@ function _segment_grid(grid::Grid, energy_tol::Float64, verbose::Bool)
         :Segment_No, grid.origin)
     segment_no = 0
     for i = 1:grid.n_pts[1], j = 1:grid.n_pts[2], k = 1:grid.n_pts[3]
-        if segmented_grid.data[i, j, k] == 0 # not yet assigned segment 
+        if segmented_grid.data[i, j, k] == 0 # not yet assigned segment
             if grid.data[i, j, k] > energy_tol # not accessible
                 segmented_grid.data[i, j, k] = -1
             else # accessible
@@ -457,13 +459,13 @@ function _note_connection!(segment_1::Int, segment_2::Int, connections::Array{Se
     if (segment_1 == -1) || (segment_2 == -1)
         return nothing
     end
-    
+
     # construct edge; if not in list of edges, push it and note connection
     segment_connection = SegmentConnection(segment_1, segment_2, direction)
     if ! (segment_connection in connections)
         push!(connections, segment_connection)
         if verbose
-            @printf("Noted seg. %d --> %d connection in (%d, %d, %d) direction.\n", 
+            @printf("Noted seg. %d --> %d connection in (%d, %d, %d) direction.\n",
                     segment_1, segment_2, direction[1], direction[2], direction[3])
         end
         # also add opposite direction to take into account symmetry
@@ -480,7 +482,7 @@ function _build_list_of_connections(segmented_grid::Grid; verbose::Bool=true)
 
     # loop over faces of unit cell
     for i = 1:segmented_grid.n_pts[1], j = 1:segmented_grid.n_pts[2]
-        _note_connection!(segmented_grid.data[i, j, end], segmented_grid.data[i, j, 1], 
+        _note_connection!(segmented_grid.data[i, j, end], segmented_grid.data[i, j, 1],
             connections, (0, 0, 1), verbose)
     end
 
@@ -488,32 +490,32 @@ function _build_list_of_connections(segmented_grid::Grid; verbose::Bool=true)
         _note_connection!(segmented_grid.data[end, j, k], segmented_grid.data[1, j, k],
             connections, (1, 0, 0), verbose)
     end
-    
+
     for i = 1:segmented_grid.n_pts[1], k = 1:segmented_grid.n_pts[3]
         _note_connection!(segmented_grid.data[i, end, k], segmented_grid.data[i, 1, k],
             connections, (0, 1, 0), verbose)
     end
-    
+
     return connections
 end
 
 function _translate_into_graph(segmented_grid::Grid, connections::Array{SegmentConnection, 1})
     nb_segments = _count_segments(segmented_grid)
-        
+
     # directed graph
     graph = DiGraph(nb_segments)
 
     # so each edge REALLY has some data associated with it: which unit cell face is traversed
     #  when traveling from the source segment to the destination segment.
-    #  goal: include this info about an edge indirectly by having an artificial vertex 
+    #  goal: include this info about an edge indirectly by having an artificial vertex
     #  indicating the direction. so all vertices have a direction. if the vertex is actually
-    #  for representing a segment, it doens't have a direction, so we assign it a 
+    #  for representing a segment, it doens't have a direction, so we assign it a
     #  direction `nothing`.
     vertex_to_direction = Dict{Int, Union{Nothing, Tuple{Int, Int, Int}}}()
     for v in vertices(graph)
         vertex_to_direction[v] = nothing
     end
-    
+
     # loop over edges, add edges to graph but with intermediate dummy vertex corresponding
     #  to direction
     for segment_connection in connections
@@ -532,20 +534,20 @@ function _translate_into_graph(segmented_grid::Grid, connections::Array{SegmentC
     return graph, vertex_to_direction
 end
 
-function _classify_segments(segmented_grid::Grid, graph::SimpleDiGraph{Int64}, 
+function _classify_segments(segmented_grid::Grid, graph::SimpleDiGraph{Int64},
                             vertex_to_direction::Dict{Int, Union{Nothing, Tuple{Int, Int, Int}}},
                             verbose::Bool=true)
     nb_segments = _count_segments(segmented_grid)
 
     # 0 = inaccessible, 1 = accessible. start out with assuming inaccessible.
     segment_classifiction = zeros(Int, nb_segments)
-    
+
     # look for simple cycles in the graph
     all_cycles = simplecycles(graph)
     if verbose
         @printf("\tFound %d simple cycles in segment connectivity graph.\n", length(all_cycles))
     end
-    
+
     # all edges involved in a cycle are connected together and are accessible channels
     for cyc in all_cycles
         @assert vertex_to_direction[cyc[1]] == nothing "shld start with segment."
@@ -594,7 +596,7 @@ function _classify_segments(segmented_grid::Grid, graph::SimpleDiGraph{Int64},
     return segment_classifiction
 end
 
-function _assign_inaccessible_pockets_minus_one!(segmented_grid::Grid, 
+function _assign_inaccessible_pockets_minus_one!(segmented_grid::Grid,
             segment_classifiction::Array{Int, 1}; verbose::Bool=true)
     for s = 1:length(segment_classifiction)
         if segment_classifiction[s] == 1
@@ -611,8 +613,8 @@ function _assign_inaccessible_pockets_minus_one!(segmented_grid::Grid,
 end
 
 """
-    accessibility_grid, nb_segments_blocked, porosity = compute_accessibility_grid(crystal, 
-    probe_molecule, ljforcefield; n_pts=(20, 20, 20), energy_tol=10.0, energy_unit=:kJ_mol,
+    accessibility_grid, nb_segments_blocked, porosity = compute_accessibility_grid(crystal,
+    probe_molecule, ljforcefield; grid_dx=1.0, energy_tol=10.0, energy_unit=:kJ_mol,
     verbose=true, write_b4_after_grids=false, block_inaccessible_pockets=true)
 
 Overlay a grid of points about the unit cell. Compute the potential energy of a probe
@@ -636,11 +638,11 @@ of segments that were blocked because they were determined to be inaccessible.
 
 # Arguments
 * `crystal::Crystal`: the crystal for which we seek to compute an accessibility grid.
-* `probe_molecule::Molecule` a molecule serving as a probe to determine whether a given 
+* `probe_molecule::Molecule` a molecule serving as a probe to determine whether a given
 point can be occupied and accessed.
-* `LJForceField::LJForceField`: the force field used to compute the potential energy of 
+* `LJForceField::LJForceField`: the force field used to compute the potential energy of
 the probe molecule
-* `n_pts::Tuple{Int, Int, Int}`: number of grid points in a, b, c directions
+* `grid_dx::Float64`: maximum distance between grid points, in Å
 * `energy_tol::Float64`: if the computed potential energy is less than this, we declare the
 grid point to be occupiable. Also this is the energy barrier beyond which we assume the
 probe adsorbate cannot pass. Units given by `energy_units` argument
@@ -651,29 +653,29 @@ threshold for occupiability and whether molecule can percolate over barrier in c
 before and after flood fill/blocking inaccessible pockets
 """
 function compute_accessibility_grid(crystal::Crystal, probe::Molecule, forcefield::LJForceField;
-                                    n_pts::Tuple{Int, Int, Int}=(20, 20, 20), 
+                                    grid_dx::Float64=1.0,
                                     energy_tol::Float64=10.0,  energy_units::Symbol=:kJ_mol,
-                                    verbose::Bool=true, write_b4_after_grids::Bool=true, 
+                                    verbose::Bool=true, write_b4_after_grids::Bool=true,
                                     block_inaccessible_pockets::Bool=true)
     assert_P1_symmetry(crystal)
     if verbose
         printstyled(@sprintf("Computing accessibility grid of %s using %f %s potential energy tol and %s probe...\n",
             crystal.name, energy_tol, energy_units, probe.species), color=:green)
     end
-    
+
     # write potential energy grid
-    grid = energy_grid(crystal, probe, forcefield, n_pts=n_pts, verbose=verbose, 
+    grid = energy_grid(crystal, probe, forcefield, grid_dx=grid_dx, verbose=verbose,
                        units=energy_units)
 
     if ! block_inaccessible_pockets
-        accessibility_grid = Grid{Bool}(grid.box, grid.n_pts, grid.data .< energy_tol, 
+        accessibility_grid = Grid{Bool}(grid.box, grid.n_pts, grid.data .< energy_tol,
                                         :accessibility, grid.origin)
 
         porosity = sum(accessibility_grid.data) / length(accessibility_grid.data)
 
         return accessibility_grid, 0, porosity
     end
-    
+
     # flood fill and label segments
     segmented_grid = _segment_grid(grid, energy_tol, verbose)
 
@@ -685,7 +687,7 @@ function compute_accessibility_grid(crystal::Crystal, probe::Molecule, forcefiel
             replace(forcefield.name, ".csv" => ""))
         write_cube(_segmented_grid, gridfilename)
     end
-    
+
     # get list of edges describing connectivity of segments across unit cell boundaries
     connections = _build_list_of_connections(segmented_grid, verbose=verbose)
 
@@ -698,23 +700,23 @@ function compute_accessibility_grid(crystal::Crystal, probe::Molecule, forcefiel
 
     # assign inaccessible pockets minus one if cycle not found in graph
     _assign_inaccessible_pockets_minus_one!(segmented_grid, segment_classifications, verbose=verbose)
-    
+
     # -1 for not accessible, 1 for accessible
     segmented_grid.data[segmented_grid.data .!= -1] .= 1
-    
+
     if write_b4_after_grids
         gridfilename = @sprintf("%s_in_%s_%s_after_pocket_blocking.cube", probe.species,
             replace(replace(crystal.name, ".cif" => ""), ".cssr" => ""),
             replace(forcefield.name, ".csv" => ""))
         write_cube(segmented_grid, gridfilename)
     end
-    
+
     # print warning if there is no use in running a simulation since all pockets are inaccessible
     if all(segmented_grid.data .== -1)
         @warn @sprintf("%s cannot enter the pores of %s with %f K energy tolerance.",
             probe.species, crystal.name, energy_tol)
     end
-    
+
     nb_segments_blocked = sum(segment_classifications .== 0)
 
     # instead of returning grid of int's return a boolean grid for storage efficiency
@@ -758,16 +760,16 @@ end
     accessible(accessibility_grid, xf)
     accessible(accessibility_grid, xf, repfactors)
 
-Using `accessibility_grid`, determine if fractional coordinate `xf` (relative to 
+Using `accessibility_grid`, determine if fractional coordinate `xf` (relative to
 `accessibility_grid.box` is accessible or not. Here, we search for the nearest grid point.
-We then look at the accessibility of this nearest grid point and all surroudning 9 other 
+We then look at the accessibility of this nearest grid point and all surroudning 9 other
 grid points. The point `xf` is declared inaccessible if and only if all 10 of these grid
 points are inaccessible. We take this approach because, if the grid is coarse, we can allow
-energy computations to automatically determine accessibility at the boundary of 
+energy computations to automatically determine accessibility at the boundary of
 accessibility e.g. during a molecular simulation where inaccessible pockets are blocked.
 
-If a tuple of replication factors are also passed, it is assumed that the passed `xf` is 
-relative to a replicated `accessibility_grid.box` so that `xf` is scaled by these rep. 
+If a tuple of replication factors are also passed, it is assumed that the passed `xf` is
+relative to a replicated `accessibility_grid.box` so that `xf` is scaled by these rep.
 factors. So `xf = [0.5, 0.25, 0.1]` with `repfactors=(1, 2, 4)` actually is, relative to
 `accessibility_grid.box`, fractional coordinate `[0.5, 0.5, 0.4]`.
 """

--- a/src/grid.jl
+++ b/src/grid.jl
@@ -243,7 +243,7 @@ function read_cube(filename::AbstractString)
 end
 
 """
-	grid = energy_grid(crystal, molecule, ljforcefield; grid_dx=1.0, temperature=298.0, n_rotations=750)
+	grid = energy_grid(crystal, molecule, ljforcefield; resolution=1.0, temperature=298.0, n_rotations=750)
 
 Superimposes a regular grid of points (regularly spaced in fractional coordinates of the `crystal.box`) over the unit cell of a crystal, with `n_gridpts` dictating the number of grid points in the a, b, c directions (including 0 and 1 fractional coords).
 The fractional coordinates 0 and 1 are included in the grid, although they are redundant.
@@ -255,7 +255,7 @@ The ensemble average is a Boltzmann average over rotations:  - R T log ⟨e⁻�
 - `crystal::Crystal`: crystal in which we seek to compute an energy grid for a molecule. `grid.box` will be `framework.box`.
 - `molecule::Molecule`: molecule for which we seek an energy grid
 - `ljforcefield::LJForceField`: molecular model for computing molecule-crystal interactions
-- `grid_dx::Float=1.0`: maximum distance between grid points, in Å
+- `resolution::Union{Float64, Tuple{Int, Int, Int}}=1.0`: maximum distance between grid points, in Å, or a tuple specifying the number of grid points in each dimension.
 - `n_rotations::Int`: number of random rotations to conduct in a Monte Carlo simulation for finding the free energy of a molecule centered at a given grid point.
 This is only relevant for molecules that are comprised of more than one Lennard Jones sphere.
 - `temperature::Float64`: the temperature at which to compute the free energy for molecules where rotations are required. Lower temperatures overemphasize the minimum potential energy rotational conformation at that point.
@@ -267,7 +267,7 @@ This is only relevant for molecules that are comprised of more than one Lennard 
 - `grid::Grid`: A grid data structure containing the potential energy of the system
 """
 function energy_grid(crystal::Crystal, molecule::Molecule{Cart}, ljforcefield::LJForceField;
-                     grid_dx::Float64=1.0, n_rotations::Int=1000,
+                     resolution::Union{Float64, Tuple{Int, Int, Int}}=1.0, n_rotations::Int=1000,
                      temperature::Float64=NaN, units::Symbol=:kJ_mol, center::Bool=false,
                      verbose::Bool=true)
     assert_P1_symmetry(crystal)
@@ -275,7 +275,7 @@ function energy_grid(crystal::Crystal, molecule::Molecule{Cart}, ljforcefield::L
         error("Pass :kJ_mol or :K for units of kJ/mol or K, respectively.")
     end
 
-    n_pts = required_n_pts(crystal.box, grid_dx)
+    n_pts = isa(resolution, Tuple{Int,Int,Int}) ? resolution : required_n_pts(crystal.box, resolution)
 
     rotations_required = needs_rotations(molecule)
     charged_system = has_charges(crystal) && has_charges(molecule)
@@ -614,7 +614,7 @@ end
 
 """
     accessibility_grid, nb_segments_blocked, porosity = compute_accessibility_grid(crystal,
-    probe_molecule, ljforcefield; grid_dx=1.0, energy_tol=10.0, energy_unit=:kJ_mol,
+    probe_molecule, ljforcefield; resolution::Union{Float64, Tuple{Int, Int, Int}}=1.0, energy_tol=10.0, energy_unit=:kJ_mol,
     verbose=true, write_b4_after_grids=false, block_inaccessible_pockets=true)
 
 Overlay a grid of points about the unit cell. Compute the potential energy of a probe
@@ -642,7 +642,7 @@ of segments that were blocked because they were determined to be inaccessible.
 point can be occupied and accessed.
 * `LJForceField::LJForceField`: the force field used to compute the potential energy of
 the probe molecule
-* `grid_dx::Float64`: maximum distance between grid points, in Å
+* - `resolution::Union{Float64, Tuple{Int, Int, Int}}=1.0`: maximum distance between grid points, in Å, or a tuple specifying the number of grid points in each dimension.
 * `energy_tol::Float64`: if the computed potential energy is less than this, we declare the
 grid point to be occupiable. Also this is the energy barrier beyond which we assume the
 probe adsorbate cannot pass. Units given by `energy_units` argument
@@ -653,7 +653,7 @@ threshold for occupiability and whether molecule can percolate over barrier in c
 before and after flood fill/blocking inaccessible pockets
 """
 function compute_accessibility_grid(crystal::Crystal, probe::Molecule, forcefield::LJForceField;
-                                    grid_dx::Float64=1.0,
+                                    resolution::Union{Float64, Tuple{Int, Int, Int}}=1.0,
                                     energy_tol::Float64=10.0,  energy_units::Symbol=:kJ_mol,
                                     verbose::Bool=true, write_b4_after_grids::Bool=true,
                                     block_inaccessible_pockets::Bool=true)
@@ -664,7 +664,7 @@ function compute_accessibility_grid(crystal::Crystal, probe::Molecule, forcefiel
     end
 
     # write potential energy grid
-    grid = energy_grid(crystal, probe, forcefield, grid_dx=grid_dx, verbose=verbose,
+    grid = energy_grid(crystal, probe, forcefield, resolution=resolution, verbose=verbose,
                        units=energy_units)
 
     if ! block_inaccessible_pockets

--- a/test/grid.jl
+++ b/test/grid.jl
@@ -42,7 +42,7 @@ using Random
         write_xyz(crystal)
         molecule = Molecule("CH4")
         forcefield = LJForceField("UFF")
-        grid = energy_grid(crystal, molecule, forcefield, grid_dx=5.)
+        grid = energy_grid(crystal, molecule, forcefield, resolution=5.)
 
         # endpoints included, ensure periodic since endpoints of grid pts included
         #   first cut out huge values. 1e46 == 1.00001e46
@@ -52,7 +52,7 @@ using Random
         @test isapprox(grid.data[:, :, 1], grid.data[:, :, end], atol=1e-7)
 
         accessibility_grid, nb_segments_blocked, porosity = compute_accessibility_grid(crystal,
-            molecule, forcefield, grid_dx=2., energy_tol=0.0, verbose=false,
+            molecule, forcefield, resolution=2., energy_tol=0.0, verbose=false,
             write_b4_after_grids=true)
         @test nb_segments_blocked > 0
         if zeolite == "LTA"
@@ -89,7 +89,7 @@ using Random
 
         # w./o blocking (nb = no blocking)
         accessibility_grid_nb, nb_segments_blocked_nb, porosity_nb = compute_accessibility_grid(crystal,
-            molecule, forcefield, grid_dx=2., energy_tol=0.0, verbose=false,
+            molecule, forcefield, resolution=2., energy_tol=0.0, verbose=false,
             write_b4_after_grids=false, block_inaccessible_pockets=false)
         @test nb_segments_blocked_nb == 0
         @test porosity_nb > porosity[:after_blocking]
@@ -101,14 +101,14 @@ using Random
     molecule = Molecule("CH4")
     forcefield = LJForceField("UFF")
     accessibility_grid, nb_segments_blocked, porosity = compute_accessibility_grid(crystal,
-        molecule, forcefield, grid_dx=2., energy_tol=0.0, verbose=false,
+        molecule, forcefield, resolution=2., energy_tol=0.0, verbose=false,
         write_b4_after_grids=true)
 
     # replicate crystal and build accessibility grid that includes the other accessibility grid in a corner
     repfactors = (2, 3, 1)
     crystal = replicate(crystal, repfactors)
     rep_accessibility_grid, rep_nb_segments_blocked, porosity = compute_accessibility_grid(crystal,
-        molecule, forcefield, grid_dx=2., energy_tol=0.0, verbose=false,
+        molecule, forcefield, resolution=2., energy_tol=0.0, verbose=false,
         write_b4_after_grids=true)
     @test all(accessibility_grid.data .== rep_accessibility_grid.data[1:7, 1:7, 1:7])
     @test rep_nb_segments_blocked > 0


### PR DESCRIPTION
@SimonEnsemble this will be a breaking-change for existing energy-grid and accessibility scripts.  could refactor to allow `n_pts` arg as alternative to `grid_dx` to allow backward compatibility