### PR TITLE
fix docstrings: crystal_density & write_vtk

### DIFF
--- a/src/box.jl
+++ b/src/box.jl
@@ -165,6 +165,7 @@ Appends ".vtk" extension to `filename` automatically if not passed.
 - `filename::AbstractString`: filename of the .vtk file output (absolute path)
 - `framework::Framework`: A framework containing the crystal structure information
 - `center_at_origin::Bool`: center box at origin if true. if false, the origin is the corner of the box.
+- `verbose::Bool`: Optional argument. If true (default), the output filename is printed to the console.
 """
 function write_vtk(box::Box, filename::AbstractString; verbose::Bool=true,
                    center_at_origin::Bool=false)

--- a/src/crystal.jl
+++ b/src/crystal.jl
@@ -657,7 +657,7 @@ function molecular_weight(crystal::Crystal)
 end
 
 """
-    ρ = crystal_density(crystal) # kg/m²
+    ρ = crystal_density(crystal) # kg/m³
 
 Compute the crystal density of a crystal. Pulls atomic masses from [`read_atomic_masses`](@ref).
 


### PR DESCRIPTION
- correct units in docstring for `crystal_density`
- document "verbose" kwarg in `write_vtk`