### PR TITLE
Xtals and Polynomials compat update

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PorousMaterials"
 uuid = "68953c7c-a3c7-538e-83d3-73516288599e"
 authors = ["SimonEnsemble <cory.simon@oregonstate.edu>"]
-version = "0.4.0"
+version = "0.4.1"
 
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
@@ -28,23 +28,22 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Xtals = "ede5f01d-793e-4c47-9885-c447d1f18d6d"
 
 [compat]
-Aqua = "0.5"
-CSV = "0.8"
+Aqua = "0.5.5"
+CSV = "0.10.4"
 DataFrames = "1"
-FIGlet = "0.2"
+FIGlet = "0.2.1"
 FileIO = "1"
 Graphs = "1"
-JLD2 = "0.4"
-OffsetArrays = "0.11"
+JLD2 = "0.4.22"
+OffsetArrays = "1"
 Optim = "1"
-Polynomials = "0.6"
+Polynomials = "3"
 ProgressMeter = "1"
 Reexport = "1"
-Roots = "0.8"
-SpecialFunctions = "0.10"
-StatsBase = "0.32"
-Xtals = "~0.3.0, ~0.4.0"
-julia = "1.6"
+Roots = "2"
+SpecialFunctions = "2"
+StatsBase = "0.33.16"
+Xtals = "0.4"
 
 [extras]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"

--- a/docs/src/crystal.md
+++ b/docs/src/crystal.md
@@ -69,7 +69,7 @@ Bravais unit cell of a crystal.
 
 	# atoms = 960
 	# charges = 960
-	chemical formula: Dict(:H => 8, :S => 1, :Ca => 1, :O => 6, :C => 14)
+	chemical formula: Ca₃₂C₄₄₈H₂₅₆O₁₉₂S₃₂
 	space Group: P1
 	symmetry Operations:
 		'x, y, z'
@@ -85,12 +85,7 @@ rho = crystal_density(xtal)         # Crystal density of the crystal in kg/m^2
 mw = molecular_weight(xtal)         # The molecular weight of the unit cell in amu
 formula = chemical_formula(xtal)    # The irreducible chemical formula of the crystal
 # output
-Dict{Symbol, Int64} with 5 entries:
-  :H  => 8
-  :S  => 1
-  :Ca => 1
-  :O  => 6
-  :C  => 14
+"Ca₄C₅₆H₃₂O₂₄S₄"
 ```
 
 ## assigning new charges

--- a/src/PorousMaterials.jl
+++ b/src/PorousMaterials.jl
@@ -32,7 +32,7 @@ function __init__()
     rc[:paths][:molecules] = ""
     rc[:paths][:grids] = ""
     rc[:paths][:simulations] = ""
-    set_paths(joinpath(pwd(), "data"))
+    set_paths(joinpath(pwd(), "data"), no_warn=true)
     append_atomic_masses()
 end
 

--- a/src/eos.jl
+++ b/src/eos.jl
@@ -29,7 +29,7 @@ B(T::Float64, P::Float64, fluid::PengRobinsonFluid) = b(fluid) * P / (UNIV_GAS_C
 # root closest to unity.
 function compressibility_factor(fluid::PengRobinsonFluid, T::Float64, P::Float64)
     # construct cubic polynomial in z
-    p = Poly([-(A(T, P, fluid) * B(T, P, fluid) - B(T, P, fluid) ^ 2 - B(T, P, fluid) ^ 3),
+    p = Polynomial([-(A(T, P, fluid) * B(T, P, fluid) - B(T, P, fluid) ^ 2 - B(T, P, fluid) ^ 3),
               A(T, P, fluid) - 2 * B(T, P, fluid) - 3 * B(T, P, fluid) ^ 2,
               -(1.0 - B(T, P, fluid)),
               1.0])
@@ -114,7 +114,7 @@ function compressibility_factor(fluid::VdWFluid, T::Float64, P::Float64)
     A = P
 
     # Creates polynomial in ρ the VdW cubic function
-    p = Poly([A, B, C, D])
+    p = Polynomial([A, B, C, D])
     # Finds roots of polynomial
     rho = roots(p)
     # assigns rho to be the real root(s) and then makes it real to get rid of the 0im


### PR DESCRIPTION
Updates `Polynomials` dependency to most recent version for compatibility with newer versions of `Xtals` (0.4.4+)

Also suppresses data path warnings at module initialization.